### PR TITLE
Add error handling for missing base resume file

### DIFF
--- a/skills/resume-editor/scripts/resume_builder.py
+++ b/skills/resume-editor/scripts/resume_builder.py
@@ -603,6 +603,9 @@ def cmd_build(args: argparse.Namespace) -> None:
     output_file = output_dir / f"Resume-MATTHEW-DRUHL-{company_clean}.docx"
 
     # Open the original resume as our base (preserves all formatting perfectly)
+    if not RESUME_PATH.exists():
+        print(f"Error: Base resume not found at {RESUME_PATH}")
+        sys.exit(1)
     doc = Document(str(RESUME_PATH))
     body = doc.element.body
 

--- a/skills/resume-editor/tests/test_build_integration.py
+++ b/skills/resume-editor/tests/test_build_integration.py
@@ -70,6 +70,29 @@ def minimal_tailoring(tmp_path):
     return tailoring_file, tailoring
 
 
+class TestBuildMissingFiles:
+    """Tests for error handling when required files are missing."""
+
+    def test_missing_base_resume_exits(self, tmp_path):
+        """Should sys.exit(1) with clear message when base resume is missing."""
+        from unittest.mock import patch
+
+        tailoring_file = tmp_path / "tailoring.json"
+        tailoring_file.write_text(json.dumps({"experience": [{"company": "Test", "roles": []}]}))
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        fake_resume = tmp_path / "nonexistent.docx"
+        args = argparse.Namespace(
+            tailoring_file=str(tailoring_file),
+            output_dir=str(output_dir),
+        )
+        with patch("resume_builder.RESUME_PATH", fake_resume):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_build(args)
+            assert exc_info.value.code == 1
+
+
 class TestBuildCommand:
     """Integration tests for the build command."""
 


### PR DESCRIPTION
## Summary

- `cmd_build()` now exits with a clear error message when the base resume file is missing, instead of crashing with a generic python-docx error

## Test Plan

- [x] 66 tests pass (new test: `test_missing_base_resume_exits`)
- [x] Regression tests still green

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)