### PR TITLE
Remove redundant compact mode re-read

### DIFF
--- a/skills/resume-editor/scripts/resume_builder.py
+++ b/skills/resume-editor/scripts/resume_builder.py
@@ -856,7 +856,6 @@ def cmd_build(args: argparse.Namespace) -> None:
             role_template = company_template
 
         # Add blank paragraph after section header (skip in compact mode)
-        compact = tailoring.get("compact", False)
         if not compact and (normal_template is not None or company_template is not None):
             tmpl = company_template if company_template is not None else normal_template
             blank = create_blank_paragraph(tmpl)


### PR DESCRIPTION
## Summary

- Remove duplicate `compact = tailoring.get("compact", False)` inside the experience loop — already set earlier in `cmd_build()`

## Test Plan

- [x] 66 tests pass
- [x] Regression test confirms output unchanged

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)