### PR TITLE
Fix stale comment in test_regression.py

### DIFF
--- a/skills/resume-editor/tests/test_regression.py
+++ b/skills/resume-editor/tests/test_regression.py
@@ -7,7 +7,7 @@ refactors or bug fixes.
 
 Requires:
 - ~/Resume/applications/Generic/Resume-MATTHEW-DRUHL.docx (known-good)
-- ~/Resume/applications/Generic/tailoring-generic-v2.json (tailoring input)
+- ~/Resume/applications/Generic/tailoring-generic.json (tailoring input)
 - ~/Resume/MatthewDruhl.docx (base resume)
 """
 


### PR DESCRIPTION
## Summary
- Fix docstring referencing `tailoring-generic-v2.json` → `tailoring-generic.json`

## Test Plan
- [x] 66 tests pass

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)