### PR TITLE
Replace absolute /Users/matthewdruhl paths with ~/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@
 6. **Document everything** - Background agent outputs, designs, and research go in `content/` with descriptive names for future reference
 
 ### File Permissions
-**MARVIN workspace autonomy:** Full permission to read, write, edit, and create files within `/Users/matthewdruhl/marvin/` without asking for confirmation. This includes:
+**MARVIN workspace autonomy:** Full permission to read, write, edit, and create files within `~/marvin/` without asking for confirmation. This includes:
 - `state/` files (current.md, goals.md, todos.md)
 - `sessions/` daily logs
 - `content/` files (job tracking, notes, etc.)

--- a/content/dnd-project.md
+++ b/content/dnd-project.md
@@ -5,14 +5,14 @@ Last updated: 2026-02-07
 ---
 
 ## D&D Campaign MCP (COMPLETE)
-- **Location:** `/Users/matthewdruhl/Code/AI/DnDProject/dnd-campaign-mcp`
+- **Location:** `~/Code/AI/DnDProject/dnd-campaign-mcp`
 - **Status:** Built and connected to Claude.ai Desktop
 - **Tools:** Character management (HP, XP) + Inventory (items, wealth)
 - **Features:** Multi-character support with active character system
 - **Next:** Test in live session, consider mobile sync pattern
 
 ## D&D Character Sheet Web App (Phase 3 COMPLETE)
-- **Location:** `/Users/matthewdruhl/Code/AI/DnDProject/dnd-character-sheet`
+- **Location:** `~/Code/AI/DnDProject/dnd-character-sheet`
 - **Status:** Phase 3 COMPLETE - Backend API functional and tested
 - **Branch:** feature/phase3-backend-api
 - **Tech Stack:** React (Vite) + FastAPI + PostgreSQL (Docker)
@@ -30,7 +30,7 @@ Last updated: 2026-02-07
 - **Learning approach:** Senior dev -> junior dev teaching style, Matt writes code with guidance
 
 ## DND Combat Engine (EXISTING)
-- **Location:** `/Users/matthewdruhl/Code/AI/DnDProject/dnd-combat-engine`
+- **Location:** `~/Code/AI/DnDProject/dnd-combat-engine`
 - **Status:** 65 tests passing, core mechanics complete
 - **Tech:** Python, pytest, TDD approach
 - **Note:** Could integrate with MCP server in future, kept separate from web app

--- a/state/goals.md
+++ b/state/goals.md
@@ -19,7 +19,7 @@ Last updated: 2026-04-02
 ## Personal Goals
 
 - Exercise regularly
-- Work on DND coding project (located at `/Users/matthewdruhl/Code/AI/DnDProject`)
+- Work on DND coding project (located at `~/Code/AI/DnDProject`)
 
 ---
 


### PR DESCRIPTION
## Summary
Replace hardcoded absolute paths with ~/ in tracked files:
- CLAUDE.md — workspace autonomy path
- state/goals.md — DnD project location
- content/dnd-project.md — all project locations

Session logs left unchanged (historical records).

## Test plan
- [ ] Verify no remaining /Users/matthewdruhl in non-session tracked files

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)