### PR TITLE
chore: fix ruff merge artifacts — restore needed imports

### DIFF
--- a/content/jobs/TWC/tests/test_fill_twc_pdf.py
+++ b/content/jobs/TWC/tests/test_fill_twc_pdf.py
@@ -4,8 +4,11 @@ import csv
 import os
 import sys
 import tempfile
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
 
 # Add parent directory to path so we can import fill_twc_pdf
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/skills/resume-editor/tests/test_error_paths.py
+++ b/skills/resume-editor/tests/test_error_paths.py
@@ -15,8 +15,6 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from resume_builder import (
-    DATA_FILE,
-    RESUME_PATH,
     cmd_build,
     cmd_cover_letter,
     cmd_update,
@@ -28,7 +26,6 @@ from resume_builder import (
     score_bullet,
     score_tailoring,
 )
-
 
 # ---------------------------------------------------------------------------
 # load_data error paths

--- a/skills/update-resume/scripts/update_resume.py
+++ b/skills/update-resume/scripts/update_resume.py
@@ -17,6 +17,7 @@ Commands:
 import argparse
 import copy
 import json
+import os
 import stat
 import sys
 from datetime import datetime

--- a/skills/update-resume/tests/test_update_resume.py
+++ b/skills/update-resume/tests/test_update_resume.py
@@ -5,9 +5,6 @@ Does NOT require ~/Resume/MatthewDruhl.docx to exist — all tests use tmp_path
 fixtures or mocks.
 """
 
-import json
-import os
-import shutil
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -28,13 +25,8 @@ from update_resume import (
     cmd_scan_certs,
     cmd_show_certs,
     cmd_show_skills,
-    find_section_headers,
-    find_section_range,
-    get_paragraph_text,
-    is_section_header,
     safe_save,
 )
-
 
 # ---------------------------------------------------------------------------
 # Path constants


### PR DESCRIPTION
## Summary
The ruff auto-fix in #66 removed `import os`, `from datetime import datetime`, and `import pytest` that were actually used by batch 4 code (#64). This restores them.

Only 8 E501 (long lines in string literals) remain — intentionally left.

## Test plan
- [ ] `uvx ruff check .` shows only 8 E501 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)