### PR TITLE
chore: add pre-commit hook for ruff linting

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Pre-commit hook: run ruff on staged Python files
+# Only checks files being committed, not the whole repo
+
+STAGED_PY=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$')
+
+if [ -z "$STAGED_PY" ]; then
+    exit 0  # No Python files staged, skip
+fi
+
+# Run ruff check on staged files only
+# Uses uvx so ruff doesn't need to be installed globally
+uvx ruff check $STAGED_PY
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "Lint errors found. Fix with: uvx ruff check --fix ."
+    echo "Then re-stage and commit."
+    exit 1
+fi


### PR DESCRIPTION
## Summary
Adds a pre-commit hook that runs ruff on staged Python files. Blocks commits with lint errors.

- Hook lives in `.hooks/pre-commit` (tracked in git)
- Uses `git config core.hooksPath .hooks` to activate
- Only checks staged `.py` files, not the whole repo
- Uses `uvx ruff` so no global install needed

**Note:** After cloning, run `git config core.hooksPath .hooks` to activate the hook.

## Test plan
- [x] Verified: commit with unused import is blocked
- [x] Verified: commits with no Python files pass through

🤖 Generated with [Claude Code](https://claude.com/claude-code)