### PR TITLE
fix: add nvm node path to slack bot plist

### DIFF
--- a/integrations/slack/com.marvin.slack-bot.plist
+++ b/integrations/slack/com.marvin.slack-bot.plist
@@ -26,7 +26,7 @@
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/Users/matthewdruhl/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>/Users/matthewdruhl/.nvm/versions/node/v22.22.0/bin:/Users/matthewdruhl/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     </dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
The `.mcp.json` uses `npx dotenv-cli` to load env vars before running `workspace-mcp`. `npx` lives under `~/.nvm` which wasn't in the bot's launchd PATH, so MCP servers failed to start in `--print` mode even with `--mcp-config`.

Adds the nvm node path to the plist's PATH env var.

## Test plan
- [x] Verified `claude --print --mcp-config .mcp.json` loads Google Workspace MCP with the corrected PATH
- [x] Slack bot successfully runs Gmail check after bot restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)