### PR TITLE
fix(harden): batch 1 — code quality + gitignore

### DIFF
--- a/skills/harden/.gitignore
+++ b/skills/harden/.gitignore
@@ -1,0 +1,2 @@
+findings.json
+*.json

--- a/skills/harden/score_audit.py
+++ b/skills/harden/score_audit.py
@@ -12,6 +12,7 @@ Input JSON format:
 """
 
 import json
+import math
 import sys
 from pathlib import Path
 
@@ -22,12 +23,12 @@ SEVERITY_POINTS: dict[str, int] = {
     "low": 1,
 }
 
-GRADE_THRESHOLDS: list[tuple[int, int, str]] = [
+GRADE_THRESHOLDS: list[tuple[float, float, str]] = [
     (0, 0, "A"),
     (1, 4, "B"),
     (5, 9, "C"),
     (10, 14, "D"),
-    (15, 10_000, "F"),
+    (15, math.inf, "F"),
 ]
 
 GRADE_TO_GPA: dict[str, int] = {"A": 4, "B": 3, "C": 2, "D": 1, "F": 0}
@@ -46,7 +47,7 @@ def points_to_grade(points: int, has_critical: bool) -> str:
 def format_severity_counts(findings: list[dict]) -> str:
     counts: dict[str, int] = {}
     for f in findings:
-        sev = f["severity"].lower()
+        sev = f.get("severity", "").lower()
         counts[sev] = counts.get(sev, 0) + 1
     if not counts:
         return "—"
@@ -72,8 +73,8 @@ def compute_scorecard(findings: list[dict]) -> None:
         blocking = [f for f in scope_findings if f.get("blocking", False)]
         non_blocking = [f for f in scope_findings if not f.get("blocking", False)]
 
-        total_points = sum(SEVERITY_POINTS.get(f["severity"].lower(), 0) for f in scope_findings)
-        has_critical = any(f["severity"].lower() == "critical" for f in scope_findings)
+        total_points = sum(SEVERITY_POINTS.get(f.get("severity", "").lower(), 0) for f in scope_findings)
+        has_critical = any(f.get("severity", "").lower() == "critical" for f in scope_findings)
         grade = points_to_grade(total_points, has_critical)
         gpa_values.append(GRADE_TO_GPA[grade])
 
@@ -93,8 +94,8 @@ def compute_scorecard(findings: list[dict]) -> None:
 def main() -> None:
     if "--help" in sys.argv or "-h" in sys.argv:
         print(__doc__)
-        print("Usage: uv run python skills/harden/score_audit.py [findings.json]")
-        print("       cat findings.json | uv run python skills/harden/score_audit.py")
+        print(f"Usage: uv run python {sys.argv[0]} [findings.json]")
+        print(f"       cat findings.json | uv run python {sys.argv[0]}")
         sys.exit(0)
 
     if len(sys.argv) > 1:
@@ -102,13 +103,21 @@ def main() -> None:
         if not path.exists() or path.stat().st_size == 0:
             print("No findings — Grade: A")
             sys.exit(0)
-        findings = json.loads(path.read_text())
+        try:
+            findings = json.loads(path.read_text())
+        except json.JSONDecodeError as e:
+            print(f"Error: invalid JSON in {path}: {e}", file=sys.stderr)
+            sys.exit(1)
     else:
         data = sys.stdin.read().strip()
         if not data:
             print("No findings — Grade: A")
             sys.exit(0)
-        findings = json.loads(data)
+        try:
+            findings = json.loads(data)
+        except json.JSONDecodeError as e:
+            print(f"Error: invalid JSON on stdin: {e}", file=sys.stderr)
+            sys.exit(1)
 
     compute_scorecard(findings)
 


### PR DESCRIPTION
## Summary

Addresses 5 blocking/non-blocking code quality findings from self-audit #131:

- **CQ-1** (blocking): Wrap both `json.loads()` calls in `try/except json.JSONDecodeError` — user-friendly error + `sys.exit(1)` on bad input
- **CQ-2** (non-blocking): Replace bare `f["severity"]` with `f.get("severity", "")` consistently — no `KeyError` on malformed findings
- **CQ-3** (non-blocking): Replace magic number `10_000` with `math.inf` as F-grade upper bound — semantically correct, no arbitrary cap
- **DECOUPLE-1** (blocking): Add `skills/harden/.gitignore` excluding `findings.json` and `*.json` — prevents private audit data from leaking into the open-source repo
- **DECOUPLE-2** (non-blocking): Use `sys.argv[0]` in help text instead of hardcoded path

## Test plan
- [ ] `uv run python skills/harden/score_audit.py --help` shows correct script path
- [ ] `echo "not json" | uv run python skills/harden/score_audit.py` prints error to stderr and exits 1
- [ ] `echo '[]' | uv run python skills/harden/score_audit.py` prints "No findings — Grade: A"
- [ ] Valid findings JSON produces correct scorecard table

Closes findings CQ-1, CQ-2, CQ-3, DECOUPLE-1, DECOUPLE-2 from #131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)