### PR TITLE
feat(harden): batch 2 — phase gates, inline self-check, Check #17

### DIFF
--- a/skills/harden/SKILL.md
+++ b/skills/harden/SKILL.md
@@ -6,11 +6,10 @@ Perform a systematic hardening audit of this project. Work through each phase be
 
 ## Reference Files
 
-Load these as needed during the audit — do not read all upfront.
+**Phase gates — load only when triggered. Do not read before the gate.**
 
-- [ai-audit-checklist.md](references/ai-audit-checklist.md) — Extended AI checks (read before Scope 2)
-- [questioning-frameworks.md](references/questioning-frameworks.md) — Self-check frameworks (read after each scope)
-- [engineering-blind-spots.md](references/engineering-blind-spots.md) — Detection questions by scope (read only if initial findings for a scope total fewer than 2)
+- [ai-audit-checklist.md](references/ai-audit-checklist.md) — Extended AI checks. Load at the start of Scope 2, not before.
+- [engineering-blind-spots.md](references/engineering-blind-spots.md) — Detection questions by scope. Load only if initial findings for a scope total fewer than 2.
 
 ## Phase 0: Context Gathering
 
@@ -59,7 +58,12 @@ Work through these one at a time. For each scope:
 
 1. **Steel-man first** — Before listing findings, state why the current approach is reasonable. Acknowledge what the project does well in this area. If you skip this step, your findings will be noisy.
 2. **Explore and find issues** — Read files, check configs, scan patterns.
-3. **Self-check** — Read [questioning-frameworks.md](references/questioning-frameworks.md) and run the 5-step self-check. Drop findings that don't survive the "so what?" test.
+3. **Self-check** — Run these 5 steps. Drop findings that don't survive.
+   1. Drop any where real-world impact is negligible
+   2. Every Critical/High must cite file + line — no citation means it's not a real finding
+   3. No style flags — don't flag naming preferences or formatting choices
+   4. Respect frameworks — don't flag X if the framework handles X
+   5. Inversion pass — check for gaps your scope-by-scope scan may have missed
 4. **Summarize** — Present findings, then ask if the user wants to go deeper or move on.
 
 ### 1. Security
@@ -75,6 +79,7 @@ Work through these one at a time. For each scope:
 - Access control on AI interfaces (who can invoke the AI, rate limits, cost controls)
 - Output validation (does the system verify AI outputs before acting on them?)
 - Fragile model assumptions (hardcoded model names, unpinned versions, deterministic output expectations)
+- AI-to-code offload opportunities (tasks done by multi-step AI reasoning that a script or cheaper model could handle)
 
 For the full extended checklist (10 additional checks including tool use validation, context stuffing, agent permissions, cost control, and more), read [ai-audit-checklist.md](references/ai-audit-checklist.md) before evaluating this scope.
 
@@ -132,7 +137,7 @@ Every finding must include all of these. If you can't fill them all in, the find
 ```
 
 **Blocking** = must address before shipping. **Non-blocking** = fix when convenient.
-**Surfaced by** = which reasoning framework or method found this issue. See [questioning-frameworks.md](references/questioning-frameworks.md) for valid attributions.
+**Surfaced by** = Code reading | Pre-mortem | Inversion | Five whys | Steel-manning | Blind spots
 
 ## Scorecard
 
@@ -152,19 +157,7 @@ After completing all scopes, present a scorecard.
 
 > Run `uv run python skills/harden/score_audit.py findings.json` to auto-generate this scorecard. See script for JSON input format.
 
-**Scorecard format:**
-
-```
-| Scope | Grade | Blocking | Non-blocking |
-|-------|-------|----------|--------------|
-| Security | C | 1 critical, 1 high | 1 medium |
-| AI | B | — | 2 high |
-| Tests | D | 3 high | — |
-| Code Quality | B | — | 1 medium, 2 low |
-| Decoupling | C | 1 high | 1 high |
-
-Overall: C
-```
+**Scorecard format:** Columns: Scope | Grade | Blocking | Non-blocking. One row per scope, then Overall grade.
 
 **Overall grade:** Average of scope grades (A=4, B=3, C=2, D=1, F=0), rounded.
 
@@ -203,6 +196,7 @@ Only create issues after the user reviews and approves the batches.
 ## Rules
 
 **Hard rules — no exceptions:**
+- **Phase gate reference files.** `ai-audit-checklist.md` loads at Scope 2, not before. `engineering-blind-spots.md` loads only if fewer than 2 findings per scope. No reference file loads before its gate.
 - **Steel-man every scope.** Before listing findings, state what the project does well. If you skip this, your findings are noise.
 - **"So what?" test.** For every finding, ask: "If they ignore this, what actually happens?" If the answer is "nothing much," drop it.
 - **Findings cap: 5 per scope, 15 total.** If you found more, keep only the highest severity. This forces prioritization.
@@ -216,3 +210,13 @@ Only create issues after the user reviews and approves the batches.
 - Only flag real issues you find in the code — not theoretical risks.
 - Prioritize findings by severity: critical > high > medium > low, calibrated by Phase 0 context.
 - The scorecard, verdict, and batch plan are mandatory outputs. Do not skip them.
+
+**Performed vs. Genuine Thoroughness** — gut-check your findings across all scopes before presenting:
+
+| Fake Thoroughness | Genuine Thoroughness |
+|---|---|
+| Long list of "considerations" with no concrete code reference | Each finding cites a specific file and line |
+| Generic warnings that apply to any project | Findings specific to THIS project's architecture |
+| "Could potentially" language without evidence | "This code does X, which means Y" |
+| Flagging missing features the project doesn't need | Flagging gaps in features the project actually uses |
+| Every finding sounds equally important | Clear severity gradient with most findings at Medium/Low |

--- a/skills/harden/references/ai-audit-checklist.md
+++ b/skills/harden/references/ai-audit-checklist.md
@@ -63,6 +63,17 @@ Detailed checks for Scope 2 (AI-Specific Gaps). Read this file before evaluating
 **Severity guidance:** Medium if token waste is consistent across frequent operations (daily skills, session management). Low for rarely-used skills. Consider cumulative cost — a 40% overhead on a skill run 2x/day adds up fast.
 **Always-loaded files:** Check CLAUDE.md, system prompts, and other files loaded every session. Content that could live in on-demand skill files (setup instructions, reference tables, detailed procedures) is a per-session tax. Only behavioral guidance and core rules belong in always-loaded files.
 
+### 17. AI-to-Code Offload Opportunities
+**What to look for:** Tasks currently performed by multi-step AI reasoning that a script could handle — codebase exploration done turn-by-turn instead of via a recon script, structured data collection (file inventories, git history, dependency graphs) forcing repeated tool calls, post-AI actions (filing issues, updating files) done manually via copy-paste, repeated parsing of the same files across audit phases.
+**Example finding:** An audit skill reads 15 files individually to build a picture of the repo. A 50-line recon script could produce the same inventory in one context injection, reducing input tokens by 40-60%.
+**Severity guidance:** Medium if the pattern recurs across frequent skill runs. Low for one-off or rarely used skills.
+**Tier check:** Not all offloading requires a script. Evaluate which tier each step needs:
+- Script — structured data, math, formatting, file I/O
+- Cheap model (haiku-class) — pattern scanning, candidate flagging, output formatting
+- Full model — judgment calls, ambiguous findings, severity calibration, steel-manning
+
+Flag any step using a full model where a cheaper tier produces equivalent output.
+
 ---
 
 *Extended AI checks inspired by research on AI code quality and the [devils-advocate skill](https://github.com/notmanas/claude-code-skills/tree/main/skills/devils-advocate) by notmanas.*

--- a/skills/harden/references/questioning-frameworks.md
+++ b/skills/harden/references/questioning-frameworks.md
@@ -1,69 +1,8 @@
-# Questioning Frameworks
+# Questioning Frameworks — Attribution Reference
 
-Use these frameworks during the self-check pass after each scope. They help catch false positives, missing findings, and severity miscalibration.
+The self-check steps and reasoning frameworks are defined inline in SKILL.md.
 
-## Pre-Mortem
-
-**Prompt:** "This project shipped. It failed catastrophically. What went wrong?"
-
-Walk through a realistic failure narrative. If you can't construct one from your findings, your Critical/High findings may be inflated. If you can construct one that your findings DON'T cover, you may have missed something.
-
-## Inversion
-
-**Prompt:** "What would guarantee this project fails? Are any of those conditions present?"
-
-Flip the question. Instead of looking for problems, define what failure looks like and check if those conditions exist in the code. This catches systemic issues that individual scope checks miss.
-
-## Five Whys (Reverse)
-
-**Prompt:** For each finding, ask "Why does this matter?" five times.
-
-If you can't get past 2-3 "whys" before the answer becomes "it doesn't really matter," the finding is Low severity at best. Drop it if it doesn't survive 3 whys.
-
-## Steel-Manning
-
-**Prompt:** "What is the strongest argument that this code is correct as-is?"
-
-Before flagging something, articulate why the current approach might be intentional and reasonable. Common reasons:
-- Framework handles it (e.g., Django CSRF, React XSS escaping)
-- Scope is intentionally limited (prototype, internal tool)
-- Trade-off was made deliberately (performance vs safety)
-- The "problem" is actually standard practice for the ecosystem
-
-If the steel-man holds, don't flag it. If it partially holds, reduce severity.
-
-## The "So What?" Test
-
-**Prompt:** "If they ignore this finding, what actually happens?"
-
-| Answer | Action |
-|--------|--------|
-| "Data loss, security breach, or outage" | Keep — Critical or High |
-| "Bug in production, degraded experience" | Keep — Medium |
-| "Slightly worse code, minor inconsistency" | Demote to Low or drop |
-| "Nothing, really" | Drop it |
-
-## Self-Check Process (5 Steps)
-
-Run this after generating findings for each scope:
-
-1. **Review findings** — Drop any where real-world impact is negligible
-2. **Verify evidence** — Every Critical/High finding must cite file + line. If you can't point to specific code, it's not a real finding.
-3. **No style flags** — Don't flag naming preferences, formatting choices, or "I would have done it differently" as findings
-4. **Respect frameworks** — If a framework handles X (CSRF, XSS, SQL injection), don't flag X as missing unless the project bypasses the framework's protection
-5. **Inversion pass** — Run the inversion framework once to check for gaps your scope-by-scope scan may have missed
-
-## Performed vs Genuine Thoroughness
-
-Use this table to gut-check your findings across ALL scopes, not just AI. A long list of "considerations" with no concrete code impact is fake thoroughness.
-
-| Fake Thoroughness | Genuine Thoroughness |
-|---|---|
-| Long list of "considerations" with no concrete code reference | Each finding cites a specific file and line |
-| Generic warnings that apply to any project | Findings specific to THIS project's architecture |
-| "Could potentially" language without evidence | "This code does X, which means Y" |
-| Flagging missing features the project doesn't need | Flagging gaps in features the project actually uses |
-| Every finding sounds equally important | Clear severity gradient with most findings at Medium/Low |
+This file exists as a reference for valid `Surfaced by` attributions in the finding format.
 
 ## Framework Attribution
 


### PR DESCRIPTION
## Summary

- **AI-1** (audit #131): Self-Check 5-step list and Performed vs Genuine Thoroughness table moved inline to SKILL.md. `questioning-frameworks.md` reduced to attribution-reference-only stub — eliminates up to ~3,000 tokens/run of redundant reads (600 tokens × 5 scopes).
- **AI-2** (audit #131): Example scorecard table removed — column headers are self-explanatory; `score_audit.py` generates the output.
- **#135**: Explicit phase gate hard rule added to Rules section. Reference Files section updated with gate conditions. `questioning-frameworks.md` removed from the load list entirely.
- **#139**: Check #17 (AI-to-code offload opportunities) added to `ai-audit-checklist.md` with tier guidance (script / cheap model / full model). Matching bullet added to Scope 2 in SKILL.md.

## Files changed
- `skills/harden/SKILL.md` — phase gate rule, inlined self-check, Thoroughness table, example table removed, Scope 2 bullet, attribution values inlined in finding format
- `skills/harden/references/questioning-frameworks.md` — stripped to attribution reference only (-60 lines)
- `skills/harden/references/ai-audit-checklist.md` — Check #17 added

## Test plan
- [ ] Run `/harden` on a project — confirm `questioning-frameworks.md` is not loaded
- [ ] Confirm `ai-audit-checklist.md` is not loaded until Scope 2
- [ ] Confirm Scope 2 findings include AI-to-code offload check
- [ ] Confirm scorecard section has no example table

Closes #135. Closes #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)