### PR TITLE
feat(harden): batch 3 — tests, rounding fix, validate_findings.py

### DIFF
--- a/skills/harden/SKILL.md
+++ b/skills/harden/SKILL.md
@@ -155,7 +155,7 @@ After completing all scopes, present a scorecard.
 | D | 10-14 |
 | F | 15+ |
 
-> Run `uv run python skills/harden/score_audit.py findings.json` to auto-generate this scorecard. See script for JSON input format.
+> Run `uv run python skills/harden/validate_findings.py findings.json && uv run python skills/harden/score_audit.py findings.json` to validate then auto-generate this scorecard. See `score_audit.py` for JSON input format.
 
 **Scorecard format:** Columns: Scope | Grade | Blocking | Non-blocking. One row per scope, then Overall grade.
 

--- a/skills/harden/score_audit.py
+++ b/skills/harden/score_audit.py
@@ -80,7 +80,7 @@ def compute_scorecard(findings: list[dict]) -> None:
 
         rows.append((scope, grade, format_severity_counts(blocking), format_severity_counts(non_blocking)))
 
-    overall_gpa = round(sum(gpa_values) / len(gpa_values))
+    overall_gpa = int(sum(gpa_values) / len(gpa_values) + 0.5)
     overall_grade = GPA_TO_GRADE[overall_gpa]
 
     print("| Scope | Grade | Blocking | Non-blocking |")

--- a/skills/harden/tests/test_score_audit.py
+++ b/skills/harden/tests/test_score_audit.py
@@ -1,0 +1,165 @@
+"""Tests for score_audit.py — scorecard grade calculator."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from score_audit import compute_scorecard, points_to_grade
+
+# ---------------------------------------------------------------------------
+# points_to_grade
+# ---------------------------------------------------------------------------
+
+
+class TestPointsToGrade:
+    def test_a_zero_points_no_critical(self):
+        assert points_to_grade(0, False) == "A"
+
+    def test_b_low_points(self):
+        assert points_to_grade(1, False) == "B"
+        assert points_to_grade(4, False) == "B"
+
+    def test_c_mid_points(self):
+        assert points_to_grade(5, False) == "C"
+        assert points_to_grade(9, False) == "C"
+
+    def test_d_high_points(self):
+        assert points_to_grade(10, False) == "D"
+        assert points_to_grade(14, False) == "D"
+
+    def test_f_very_high_points(self):
+        assert points_to_grade(15, False) == "F"
+        assert points_to_grade(999, False) == "F"
+
+    def test_critical_floor_overrides_a(self):
+        assert points_to_grade(0, True) == "D"
+
+    def test_critical_floor_overrides_b(self):
+        assert points_to_grade(3, True) == "D"
+
+    def test_critical_floor_overrides_c(self):
+        assert points_to_grade(7, True) == "D"
+
+    def test_critical_floor_does_not_override_d(self):
+        assert points_to_grade(12, True) == "D"
+
+    def test_critical_floor_does_not_override_f(self):
+        assert points_to_grade(15, True) == "F"
+
+
+# ---------------------------------------------------------------------------
+# compute_scorecard
+# ---------------------------------------------------------------------------
+
+
+class TestComputeScorecard:
+    def test_empty_findings(self, capsys):
+        compute_scorecard([])
+        out = capsys.readouterr().out
+        assert "No findings" in out
+        assert "Grade: A" in out
+
+    def test_single_scope_grade_b(self, capsys):
+        findings = [
+            {"scope": "Security", "severity": "High", "blocking": True},
+        ]
+        compute_scorecard(findings)
+        out = capsys.readouterr().out
+        assert "Security" in out
+        assert "| B |" in out
+        assert "Overall: B" in out
+
+    def test_single_scope_grade_a(self, capsys):
+        compute_scorecard([{"scope": "Tests", "severity": "Low", "blocking": False}])
+        out = capsys.readouterr().out
+        assert "| B |" in out  # 1 low = 1 pt → B
+
+    def test_critical_floor_in_output(self, capsys):
+        findings = [{"scope": "Security", "severity": "Critical", "blocking": True}]
+        compute_scorecard(findings)
+        out = capsys.readouterr().out
+        assert "| D |" in out
+
+    def test_overall_grade_conventional_rounding(self, capsys):
+        # A(4) + B(3) + B(3) + F(0) = 10 / 4 = 2.5 → should be B(3), not C(2)
+        # Python banker rounding gives round(2.5) = 2 (C) — this verifies the fix.
+        findings = [
+            {"scope": "AI", "severity": "Low", "blocking": False},           # 1pt → B
+            {"scope": "Decoupling", "severity": "Low", "blocking": False},   # 1pt → B
+            {"scope": "Security", "severity": "High", "blocking": True},     # 3pt → B
+            {"scope": "Tests", "severity": "Critical", "blocking": True},    # 4pt + critical → D
+        ]
+        compute_scorecard(findings)
+        out = capsys.readouterr().out
+        # B(3) + B(3) + B(3) + D(1) = 10 / 4 = 2.5 → B with fix, C without
+        assert "Overall: B" in out
+
+    def test_missing_severity_no_keyerror(self, capsys):
+        findings = [{"scope": "Security", "blocking": True}]  # no severity field
+        compute_scorecard(findings)  # must not raise
+        out = capsys.readouterr().out
+        assert "Security" in out
+
+    def test_blocking_vs_non_blocking_columns(self, capsys):
+        findings = [
+            {"scope": "Security", "severity": "High", "blocking": True},
+            {"scope": "Security", "severity": "Low", "blocking": False},
+        ]
+        compute_scorecard(findings)
+        out = capsys.readouterr().out
+        assert "1 high" in out
+        assert "1 low" in out
+
+    def test_multiple_scopes_sorted(self, capsys):
+        findings = [
+            {"scope": "Tests", "severity": "High", "blocking": True},
+            {"scope": "AI", "severity": "Low", "blocking": False},
+        ]
+        compute_scorecard(findings)
+        out = capsys.readouterr().out
+        lines = out.splitlines()
+        scope_lines = [line for line in lines if "AI" in line or "Tests" in line]
+        assert scope_lines[0].startswith("| AI")
+        assert scope_lines[1].startswith("| Tests")
+
+    def test_f_grade_scope(self, capsys):
+        # 4 highs = 12pts → D; 5 highs = 15pts → F
+        findings = [
+            {"scope": "Code Quality", "severity": "High", "blocking": True},
+        ] * 5
+        compute_scorecard(findings)
+        out = capsys.readouterr().out
+        assert "| F |" in out
+
+
+# ---------------------------------------------------------------------------
+# CLI (invalid JSON → exit 1)
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def _run(self, input_data: str) -> subprocess.CompletedProcess:
+        script = Path(__file__).parent.parent / "score_audit.py"
+        return subprocess.run(
+            ["python", str(script)],
+            input=input_data,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_invalid_json_exits_1(self):
+        result = self._run("not json")
+        assert result.returncode == 1
+        assert "Error" in result.stderr
+
+    def test_empty_input_exits_0(self):
+        result = self._run("")
+        assert result.returncode == 0
+        assert "Grade: A" in result.stdout
+
+    def test_valid_findings_exits_0(self):
+        findings = '[{"scope":"Security","severity":"High","blocking":true}]'
+        result = self._run(findings)
+        assert result.returncode == 0
+        assert "Overall:" in result.stdout

--- a/skills/harden/validate_findings.py
+++ b/skills/harden/validate_findings.py
@@ -1,0 +1,82 @@
+"""
+validate_findings.py — Validate findings JSON before passing to score_audit.py.
+
+Checks each finding has required fields with valid values.
+Exits 0 if valid (or no findings), 1 with errors listed if invalid.
+
+Usage:
+  uv run python skills/harden/validate_findings.py findings.json
+  cat findings.json | uv run python skills/harden/validate_findings.py
+"""
+
+import json
+import sys
+from pathlib import Path
+
+VALID_SEVERITIES = {"critical", "high", "medium", "low"}
+REQUIRED_FIELDS = ("scope", "severity", "blocking")
+
+
+def validate(findings: list[dict]) -> list[str]:
+    errors: list[str] = []
+    for i, f in enumerate(findings):
+        label = f"Finding[{i}] (scope={f.get('scope', '?')})"
+        for field in REQUIRED_FIELDS:
+            if field not in f:
+                errors.append(f"{label}: missing required field '{field}'")
+        sev = f.get("severity", "")
+        if sev and sev.lower() not in VALID_SEVERITIES:
+            errors.append(
+                f"{label}: invalid severity '{sev}' — must be one of: "
+                + ", ".join(sorted(VALID_SEVERITIES))
+            )
+        blocking = f.get("blocking")
+        if blocking is not None and not isinstance(blocking, bool):
+            errors.append(
+                f"{label}: 'blocking' must be a boolean, got {type(blocking).__name__}"
+            )
+    return errors
+
+
+def main() -> None:
+    if "--help" in sys.argv or "-h" in sys.argv:
+        print(__doc__)
+        sys.exit(0)
+
+    if len(sys.argv) > 1:
+        path = Path(sys.argv[1])
+        if not path.exists():
+            print(f"Error: file not found: {path}", file=sys.stderr)
+            sys.exit(1)
+        try:
+            findings = json.loads(path.read_text())
+        except json.JSONDecodeError as e:
+            print(f"Error: invalid JSON in {path}: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        data = sys.stdin.read().strip()
+        if not data:
+            print("No findings to validate.")
+            sys.exit(0)
+        try:
+            findings = json.loads(data)
+        except json.JSONDecodeError as e:
+            print(f"Error: invalid JSON on stdin: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    if not isinstance(findings, list):
+        print("Error: findings must be a JSON array", file=sys.stderr)
+        sys.exit(1)
+
+    errors = validate(findings)
+    if errors:
+        print(f"Validation failed — {len(errors)} error(s):")
+        for err in errors:
+            print(f"  {err}")
+        sys.exit(1)
+
+    print(f"Valid — {len(findings)} finding(s) passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **TEST-1**: `skills/harden/tests/test_score_audit.py` — 22 tests across three classes:
  - `TestPointsToGrade` — grades A–F, critical floor overrides A/B/C but not D/F
  - `TestComputeScorecard` — empty input, single/multi-scope, blocking columns, missing severity (no KeyError), alphabetical sort, F-grade scope
  - `TestCLI` — invalid JSON exits 1 with stderr, empty stdin exits 0, valid findings exits 0
- **TEST-2**: Fix banker rounding — `round(2.5)` returns 2 (C) in Python; `int(2.5 + 0.5)` returns 3 (B). Audit scenario: A+B+B+F scopes average 2.5 GPA and now correctly score B overall.
- **AI-3**: `skills/harden/validate_findings.py` — validates required fields (`scope`, `severity`, `blocking`), rejects invalid severity values, enforces boolean type on `blocking`. Run before `score_audit.py` to catch malformed input early with clear error messages.
- **SKILL.md**: Updated scorecard script note to chain `validate_findings.py && score_audit.py`.

## Test plan
- [x] 22/22 tests pass (`uv run --with pytest pytest skills/harden/tests/ -v`)
- [ ] `echo '[{"scope":"X","severity":"bad","blocking":true}]' | uv run python skills/harden/validate_findings.py` → exits 1, prints invalid severity error
- [ ] `echo '[]' | uv run python skills/harden/validate_findings.py` → "No findings to validate."

Closes findings TEST-1, TEST-2, AI-3 from #131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)