### PR TITLE
fix(marvin): remove Sync Learning Tracker step from /marvin skill

### DIFF
--- a/.claude/commands/marvin.md
+++ b/.claude/commands/marvin.md
@@ -19,13 +19,6 @@ Run `date +%Y-%m-%d` to get today's date. Store as TODAY.
 - `sessions/{TODAY}.md` - If exists, we're resuming today's session
 - If no today file, read the most recent file in `sessions/` for continuity
 
-### 2b. Sync Learning Tracker
-Update learning tracker with new topics from `~/Code/Learning/topics-learned.md`:
-- Do not repeat information already in `state/learning.md`
-- `Issues Needing More Guidance` items start at confidence 1/5
-- `Topics Covered` and `Key Concepts Practiced` start at confidence 2/5
-- Show a summary of what was added
-
 ### 3. Check Gmail for Job Responses
 Automatically search Gmail for responses to active job applications:
 - Read `~/Resume/jobs/applications.md` for active applications


### PR DESCRIPTION
## Summary
- Removes the `2b. Sync Learning Tracker` block from the `/marvin` startup skill
- Learning sync belongs in `/learn-sync` (on-demand), not in every session start
- Reduces context window load on `/marvin` invocation by skipping the full read of `topics-learned.md` + `state/learning.md`

## Test plan
- [ ] Run `/marvin` — confirm no learning sync step in output
- [ ] Run `/learn-sync` — confirm sync still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)