### PR TITLE
feat(harden): batch 5 — token logging, harden-issues wiring

### DIFF
--- a/skills/harden/.gitignore
+++ b/skills/harden/.gitignore
@@ -1,2 +1,3 @@
 findings.json
 *.json
+token_usage.csv

--- a/skills/harden/SKILL.md
+++ b/skills/harden/SKILL.md
@@ -191,7 +191,13 @@ Effort: [Low / Medium / High]
 
 After presenting the batch plan, ask: **"Ready to create GitHub issues? I'll file them in batch order."**
 
-Only create issues after the user reviews and approves the batches.
+Only create issues after the user reviews and approves the batches. Once approved, run:
+
+```
+uv run python skills/harden/harden-issues.py findings.json --repo <owner>/<repo>
+```
+
+To file a single batch only: add `--batch 1`. To preview without filing: add `--dry-run`.
 
 ## Rules
 
@@ -204,6 +210,21 @@ Only create issues after the user reviews and approves the batches.
 - **Evidence required.** Every finding must cite a file path and line. No finding based on "I didn't see X" without checking.
 - **Respect frameworks.** If the framework handles it (Django CSRF, React XSS escaping, etc.), don't flag it as missing unless the project bypasses the protection.
 - **No style opinions.** Don't flag naming preferences, formatting choices, or "I would have done it differently."
+
+## Scripts
+
+| Script | Purpose | Usage |
+|--------|---------|-------|
+| `validate_findings.py` | Validate all required fields before scoring | `uv run python skills/harden/validate_findings.py findings.json` |
+| `score_audit.py` | Compute per-scope grades and overall scorecard | `uv run python skills/harden/score_audit.py findings.json` |
+| `harden-issues.py` | File GitHub issues from findings.json in batch order | `uv run python skills/harden/harden-issues.py findings.json --repo owner/repo` |
+| `token_log.py` | Log per-run token usage to token_usage.csv | `uv run python skills/harden/token_log.py --project <name> --scope <scope> --input-tokens <N> --output-tokens <N>` |
+
+**Prerequisites for harden-issues.py:** `gh` CLI authenticated; labels `harden`, `blocking`, `Critical`, `High`, `Medium`, `Low` must exist in the target repo.
+
+**Token logging:** After each audit run, log usage with `token_log.py`. The CSV (`token_usage.csv`) is gitignored and stays local.
+
+## Rules
 
 **Standard rules:**
 - Explore the codebase yourself before asking questions. Read files, check configs, scan for patterns.

--- a/skills/harden/harden-issues.py
+++ b/skills/harden/harden-issues.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+File GitHub issues from a harden audit findings.json.
+
+Usage:
+    uv run python skills/harden/harden-issues.py findings.json --repo owner/repo
+
+Prerequisites:
+    - gh CLI installed and authenticated
+    - findings.json produced by validate_findings.py + score_audit.py pipeline
+    - GitHub labels exist: Critical, High, Medium, Low, harden, blocking
+    - GitHub milestones match batch names in the findings (optional)
+
+findings.json format (array of finding objects):
+    [
+      {
+        "id": "SEC-1",
+        "title": "Hardcoded API key in config.py",
+        "scope": "Security",
+        "severity": "Critical",
+        "blocking": true,
+        "where": "config.py:42",
+        "what": "...",
+        "proof": "...",
+        "impact": "...",
+        "fix": "...",
+        "batch": 1
+      },
+      ...
+    ]
+"""
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SEVERITY_LABELS = {"critical", "high", "medium", "low"}
+REQUIRED_FIELDS = {"id", "title", "scope", "severity", "blocking", "where", "what", "fix", "batch"}
+
+
+def build_body(f: dict) -> str:
+    blocking_str = "Yes" if f.get("blocking") else "No"
+    return f"""### {f['id']}: {f['title']}
+
+**Scope:** {f['scope']}
+**Severity:** {f['severity']}
+**Blocking:** {blocking_str}
+**Where:** `{f['where']}`
+
+**What:**
+{f.get('what', '')}
+
+**Proof:**
+{f.get('proof', '')}
+
+**Impact:**
+{f.get('impact', '')}
+
+**Fix:**
+{f.get('fix', '')}
+
+---
+*Filed by harden-issues.py from audit findings.json*
+"""
+
+
+def create_issue(finding: dict, repo: str, batch: int, dry_run: bool) -> None:
+    labels = ["harden", finding["severity"].lower()]
+    if finding.get("blocking"):
+        labels.append("blocking")
+
+    title = f"[harden] {finding['id']}: {finding['title']}"
+    body = build_body(finding)
+
+    cmd = [
+        "gh", "issue", "create",
+        "--repo", repo,
+        "--title", title,
+        "--body", body,
+        "--label", ",".join(labels),
+    ]
+
+    if dry_run:
+        print(f"[dry-run] Would create: {title}")
+        print(f"          Labels: {labels}")
+        return
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"ERROR creating issue for {finding['id']}: {result.stderr.strip()}", file=sys.stderr)
+    else:
+        print(f"Created: {result.stdout.strip()}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="File GitHub issues from harden audit findings")
+    parser.add_argument("findings", help="Path to findings.json")
+    parser.add_argument("--repo", required=True, help="GitHub repo in owner/repo format")
+    parser.add_argument("--dry-run", action="store_true", help="Print what would be created without filing")
+    parser.add_argument("--batch", type=int, default=None, help="Only file issues for this batch number")
+    args = parser.parse_args()
+
+    findings_path = Path(args.findings)
+    if not findings_path.exists():
+        print(f"ERROR: {findings_path} not found", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        findings = json.loads(findings_path.read_text())
+    except json.JSONDecodeError as e:
+        print(f"ERROR: Invalid JSON in {findings_path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not isinstance(findings, list):
+        print("ERROR: findings.json must be a JSON array", file=sys.stderr)
+        sys.exit(1)
+
+    # Filter by batch if specified
+    if args.batch is not None:
+        findings = [f for f in findings if f.get("batch") == args.batch]
+        print(f"Filing {len(findings)} issue(s) for batch {args.batch}")
+    else:
+        print(f"Filing {len(findings)} issue(s) across all batches")
+
+    # Validate required fields
+    errors = []
+    for i, f in enumerate(findings):
+        missing = REQUIRED_FIELDS - set(f.keys())
+        if missing:
+            errors.append(f"Finding {i}: missing fields {missing}")
+        if f.get("severity", "").lower() not in SEVERITY_LABELS:
+            errors.append(f"Finding {i} ({f.get('id', '?')}): invalid severity '{f.get('severity')}'")
+
+    if errors:
+        print("Validation errors — fix before filing:", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # File in batch order
+    findings_sorted = sorted(findings, key=lambda f: (f.get("batch", 99), f.get("id", "")))
+    for finding in findings_sorted:
+        create_issue(finding, repo=args.repo, batch=finding.get("batch", 1), dry_run=args.dry_run)
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/harden/token_log.py
+++ b/skills/harden/token_log.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Log per-run token usage for /harden audits."""
+import argparse
+import csv
+import os
+from datetime import date
+
+LOG_FILE = os.path.join(os.path.dirname(__file__), "token_usage.csv")
+FIELDNAMES = ["date", "project", "scope", "input_tokens", "output_tokens", "total_tokens"]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Log harden audit token usage")
+    parser.add_argument("--project", required=True, help="Project name being audited")
+    parser.add_argument("--scope", required=True, help="Scope name (e.g. Security, AI, Tests, All)")
+    parser.add_argument("--input-tokens", type=int, required=True, dest="input_tokens")
+    parser.add_argument("--output-tokens", type=int, required=True, dest="output_tokens")
+    args = parser.parse_args()
+
+    write_header = not os.path.exists(LOG_FILE)
+    with open(LOG_FILE, "a", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=FIELDNAMES)
+        if write_header:
+            writer.writeheader()
+        total = args.input_tokens + args.output_tokens
+        writer.writerow({
+            "date": date.today().isoformat(),
+            "project": args.project,
+            "scope": args.scope,
+            "input_tokens": args.input_tokens,
+            "output_tokens": args.output_tokens,
+            "total_tokens": total,
+        })
+    print(f"Logged: {args.project} / {args.scope} — {args.input_tokens + args.output_tokens:,} tokens total")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `token_log.py`: appends per-run token usage to `token_usage.csv` (gitignored); supports `--project`, `--scope`, `--input-tokens`, `--output-tokens`
- Add `harden-issues.py`: files GitHub issues from `findings.json` in batch order; supports `--dry-run`, `--batch`, `--repo`
- Wire `harden-issues.py` into SKILL.md: explicit run command appears after user approves the batch plan
- Add Scripts reference table to SKILL.md for all four harden scripts (`validate_findings.py`, `score_audit.py`, `harden-issues.py`, `token_log.py`)
- Add `token_usage.csv` to `.gitignore`

## Issues closed
- closes #133
- closes #138

🤖 Generated with Claude Code