### PR TITLE
docs: add RTK setup step and branch guard to /commit skill

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -18,4 +18,8 @@ git config core.hooksPath .hooks
 for skill in skills/grill-me skills/harden skills/improve-codebase-architecture skills/prd-to-issues skills/tdd skills/write-a-prd; do
   ln -sf "$PWD/$skill" "$HOME/.claude/skills/$(basename $skill)"
 done
+
+# 3. Install RTK — compresses Bash command output to reduce token usage (60-90% on git, tests, etc.)
+brew install rtk
+rtk init -g   # adds a hook to ~/.claude/settings.json; restart Claude Code after
 ```

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -24,6 +24,17 @@ Review changes and create clean, well-structured git commits.
 
 ## Process
 
+### Step 0: Branch Check
+
+```bash
+git branch --show-current
+```
+
+If on `main`:
+1. Ask the user for a branch name, or suggest one based on the staged changes (e.g. `docs/setup-rtk`, `fix/login-timeout`)
+2. Create and switch to the branch: `git checkout -b <branch-name>`
+3. Then proceed with the commit steps below
+
 ### Step 1: Check Current Status
 ```bash
 git status --short


### PR DESCRIPTION
## Summary
- Adds RTK install instructions to `SETUP.md` as step 3 in the After Cloning setup
- Updates `/commit` skill to check if on `main` and create a feature branch before committing

## Test plan
- [ ] Clone fresh and verify RTK install step is clear in SETUP.md
- [ ] Run `/commit` while on `main` and confirm it prompts for a branch name

🤖 Generated with [Claude Code](https://claude.com/claude-code)