### PR TITLE
feat(skills): add youtube-transcribe skill

### DIFF
--- a/.claude/commands/youtube-transcribe.md
+++ b/.claude/commands/youtube-transcribe.md
@@ -1,0 +1,21 @@
+---
+description: Download and clean a YouTube transcript from a video URL
+---
+
+# /youtube-transcribe
+
+Download auto-generated subtitles from a YouTube video and strip SRT formatting to produce a clean plain-text transcript.
+
+## Instructions
+
+The user has provided a YouTube URL: `$ARGUMENTS`
+
+Run the transcribe script:
+
+```bash
+bash skills/youtube-transcribe/transcribe.sh "$ARGUMENTS"
+```
+
+After it completes:
+1. Confirm `transcript.txt` was created
+2. Ask if the user wants to view the contents or have the video summarized

--- a/skills/youtube-transcribe/SKILL.md
+++ b/skills/youtube-transcribe/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: youtube-transcribe
+description: |
+  Download and clean a YouTube video transcript using auto-generated subtitles.
+  Strips SRT timing/sequence formatting and outputs plain readable text.
+license: MIT
+compatibility: marvin
+metadata:
+  marvin-category: utility
+  user-invocable: true
+  slash-command: youtube-transcribe
+  model: default
+  proactive: false
+---
+
+# YouTube Transcribe
+
+Downloads auto-generated subtitles from a YouTube video and strips SRT formatting to produce a clean plain-text transcript.
+
+## When to Use
+
+- User provides a YouTube URL and wants a transcript
+- User says "transcribe", "get transcript", "download subtitles", etc.
+
+## Process
+
+### Step 1: Run the shell script
+
+Execute with the URL the user provided:
+
+```bash
+bash skills/youtube-transcribe/transcribe.sh "<url>"
+```
+
+This runs two commands:
+1. `yt-dlp` downloads the auto-generated subtitles as `transcript.en.srt`
+2. `sed` strips sequence numbers, timestamps, and blank lines → `transcript.txt`
+
+### Step 2: Confirm output
+
+Tell the user:
+- Where the transcript was saved (`transcript.txt` in the current directory)
+- Offer to display the contents or summarize the video
+
+## Output
+
+- `transcript.en.srt` — raw subtitle file (intermediate, can discard)
+- `transcript.txt` — clean plain-text transcript
+
+## Notes
+
+- Requires `yt-dlp` installed (`brew install yt-dlp`)
+- Only works if the video has auto-generated or manual subtitles
+- If the video has no English subtitles, `yt-dlp` will report no subtitles found — inform the user
+
+---
+
+*Skill created: 2026-04-10*

--- a/skills/youtube-transcribe/transcribe.sh
+++ b/skills/youtube-transcribe/transcribe.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# youtube-transcribe: download auto-generated subtitles and strip SRT formatting
+# Usage: ./transcribe.sh <youtube-url>
+
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+    echo "Usage: $0 <youtube-url>" >&2
+    exit 1
+fi
+
+URL="$1"
+
+echo "Downloading transcript for: $URL"
+yt-dlp --write-auto-sub --sub-format srt --skip-download --output "transcript" "$URL"
+
+echo "Cleaning SRT formatting..."
+sed '/^[0-9]*$/d; /^[0-9:,]* --> /d; /^$/d' transcript.en.srt > transcript.txt
+
+echo "Done. Transcript saved to: transcript.txt"


### PR DESCRIPTION
## Summary

- Adds `/youtube-transcribe <url>` slash command
- Shell script (`transcribe.sh`) downloads auto-generated subtitles via `yt-dlp` and strips SRT formatting to produce a clean plain-text `transcript.txt`
- After transcription, prompts to view or summarize the content

## Test plan

- [ ] Run `/youtube-transcribe <youtube-url>` and verify `transcript.txt` is created
- [ ] Verify SRT timestamps and formatting are stripped from output
- [ ] Confirm summarization prompt appears after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)