### PR TITLE
fix(harden): batch 1 — agent scope, schema dedup, token capture, tests

### DIFF
--- a/skills/harden/SKILL.md
+++ b/skills/harden/SKILL.md
@@ -58,6 +58,8 @@ Note the printed marker path.
 >
 > Follow all instructions in `~/.claude/skills/harden/SKILL.md` starting from **Severity Definitions** through **Batch Plan**. Write findings to `findings.json` in the audited project directory using the JSON format from `score_audit.py`.
 >
+> **Scope restriction:** Only write to `findings.json` in the audited project directory. Do not modify any other files — in particular, do not write to any MARVIN state files (current.md, goals.md, decisions.md, todos.md, habits.md, learning.md) or any file outside the audited project directory.
+>
 > **Final step (token capture) — run after writing findings.json:**
 > ```bash
 > uv run python ~/.claude/skills/harden/capture_tokens.py --project [project-name] --scope [scope] --marker [MARKER path from Step 1]

--- a/skills/harden/capture_tokens.py
+++ b/skills/harden/capture_tokens.py
@@ -3,33 +3,79 @@
 import argparse
 import csv
 import json
+import time
 from datetime import date
 from pathlib import Path
 
 LOG_FILE = Path(__file__).parent / "token_usage.csv"
 FIELDNAMES = ["date", "project", "scope", "input_tokens", "output_tokens", "total_tokens"]
 
+# Lookback window for time-based JSONL search (seconds). Covers long audits.
+RECENT_WINDOW_SECS = 7200  # 2 hours
 
-def get_project_dir() -> Path:
-    """Compute Claude Code project directory from current working directory."""
+
+def get_project_dir(override: str | None = None) -> Path:
+    """Compute Claude Code project directory.
+
+    If override is provided, use it directly (allows caller to specify the
+    project dir when the agent's cwd differs from the audited project path).
+    Otherwise fall back to computing from cwd.
+    """
+    if override:
+        return Path(override)
     cwd = str(Path.cwd())
     project_hash = cwd.replace("/", "-").lstrip("-")
     return Path.home() / ".claude" / "projects" / project_hash
 
 
-def find_agent_jsonl(project_dir: Path, marker_path: Path | None) -> Path | None:
-    """Find the background agent JSONL — most recently modified after the start marker."""
+def find_agent_jsonl(
+    project_dir: Path,
+    marker_path: Path | None,
+    verbose: bool = False,
+) -> Path | None:
+    """Find the background agent JSONL — newest file created within the lookback window.
+
+    Strategy (in order):
+    1. If a marker exists, use files modified after the marker mtime.
+    2. Fall back to files modified within RECENT_WINDOW_SECS of now.
+    3. Last resort: most recently modified file across all subagents.
+    """
     subagent_files = list(project_dir.glob("*/subagents/*.jsonl"))
+
+    if verbose:
+        print(f"[verbose] project_dir: {project_dir}")
+        print(f"[verbose] subagent files found: {len(subagent_files)}")
+        for f in subagent_files:
+            print(f"  {f}  mtime={f.stat().st_mtime:.0f}")
+        if marker_path:
+            if marker_path.exists():
+                print(f"[verbose] marker mtime: {marker_path.stat().st_mtime:.0f}")
+            else:
+                print(f"[verbose] marker not found: {marker_path}")
+
     if not subagent_files:
         return None
 
+    # Strategy 1: marker-relative filter
     if marker_path and marker_path.exists():
         marker_mtime = marker_path.stat().st_mtime
         recent = [f for f in subagent_files if f.stat().st_mtime >= marker_mtime]
+        if verbose:
+            print(f"[verbose] files after marker: {len(recent)}")
         if recent:
             return max(recent, key=lambda p: p.stat().st_mtime)
 
-    # Fallback: most recently modified
+    # Strategy 2: time-based window (handles race condition where marker is gone)
+    cutoff = time.time() - RECENT_WINDOW_SECS
+    recent = [f for f in subagent_files if f.stat().st_mtime >= cutoff]
+    if verbose:
+        print(f"[verbose] files within {RECENT_WINDOW_SECS}s window: {len(recent)}")
+    if recent:
+        return max(recent, key=lambda p: p.stat().st_mtime)
+
+    # Strategy 3: absolute fallback
+    if verbose:
+        print("[verbose] falling back to most recently modified file")
     return max(subagent_files, key=lambda p: p.stat().st_mtime)
 
 
@@ -75,12 +121,20 @@ def main() -> None:
     parser.add_argument("--project", required=True, help="Project name being audited")
     parser.add_argument("--scope", default="All", help="Scope audited (e.g. All, Security, AI)")
     parser.add_argument("--marker", help="Path to start marker file (created before agent launch)")
+    parser.add_argument(
+        "--project-dir",
+        help="Explicit Claude project directory path (overrides cwd-based computation)",
+    )
+    parser.add_argument(
+        "--verbose", action="store_true",
+        help="Print debug info: project_dir, found JSONLs, mtime values",
+    )
     args = parser.parse_args()
 
-    project_dir = get_project_dir()
+    project_dir = get_project_dir(args.project_dir)
     marker_path = Path(args.marker) if args.marker else None
 
-    jsonl_path = find_agent_jsonl(project_dir, marker_path)
+    jsonl_path = find_agent_jsonl(project_dir, marker_path, verbose=args.verbose)
     if not jsonl_path:
         print(f"No agent JSONL found in {project_dir}")
         raise SystemExit(1)

--- a/skills/harden/harden-issues.py
+++ b/skills/harden/harden-issues.py
@@ -35,8 +35,8 @@ import subprocess
 import sys
 from pathlib import Path
 
-SEVERITY_LABELS = {"critical", "high", "medium", "low"}
-REQUIRED_FIELDS = {"id", "title", "scope", "severity", "blocking", "where", "what", "fix", "batch"}
+from schema import REQUIRED_FIELDS
+from schema import VALID_SEVERITIES as SEVERITY_LABELS
 
 
 def build_body(f: dict) -> str:
@@ -93,6 +93,18 @@ def create_issue(finding: dict, repo: str, batch: int, dry_run: bool) -> None:
         print(f"Created: {result.stdout.strip()}")
 
 
+def validate_findings(findings: list[dict]) -> list[str]:
+    """Return a list of validation error strings; empty list means valid."""
+    errors: list[str] = []
+    for i, f in enumerate(findings):
+        missing = REQUIRED_FIELDS - set(f.keys())
+        if missing:
+            errors.append(f"Finding {i}: missing fields {missing}")
+        if f.get("severity", "").lower() not in SEVERITY_LABELS:
+            errors.append(f"Finding {i} ({f.get('id', '?')}): invalid severity '{f.get('severity')}'")
+    return errors
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="File GitHub issues from harden audit findings")
     parser.add_argument("findings", help="Path to findings.json")
@@ -123,15 +135,7 @@ def main() -> None:
     else:
         print(f"Filing {len(findings)} issue(s) across all batches")
 
-    # Validate required fields
-    errors = []
-    for i, f in enumerate(findings):
-        missing = REQUIRED_FIELDS - set(f.keys())
-        if missing:
-            errors.append(f"Finding {i}: missing fields {missing}")
-        if f.get("severity", "").lower() not in SEVERITY_LABELS:
-            errors.append(f"Finding {i} ({f.get('id', '?')}): invalid severity '{f.get('severity')}'")
-
+    errors = validate_findings(findings)
     if errors:
         print("Validation errors — fix before filing:", file=sys.stderr)
         for e in errors:

--- a/skills/harden/schema.py
+++ b/skills/harden/schema.py
@@ -1,0 +1,9 @@
+"""Shared schema definitions for the harden audit pipeline."""
+
+VALID_SEVERITIES: frozenset[str] = frozenset({"critical", "high", "medium", "low"})
+
+# Superset of all fields required by the full pipeline (validate → score → issues).
+# Both validate_findings.py and harden-issues.py import from here so they stay in sync.
+REQUIRED_FIELDS: frozenset[str] = frozenset(
+    {"id", "title", "scope", "severity", "blocking", "where", "what", "fix", "batch"}
+)

--- a/skills/harden/tests/test_harden_issues.py
+++ b/skills/harden/tests/test_harden_issues.py
@@ -1,0 +1,169 @@
+"""Tests for harden-issues.py — issue creation, body building, and validation."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# harden-issues.py has a dash so it can't be imported with a plain import statement.
+_spec = importlib.util.spec_from_file_location(
+    "harden_issues",
+    Path(__file__).parent.parent / "harden-issues.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+build_body = _mod.build_body
+create_issue = _mod.create_issue
+validate_findings = _mod.validate_findings
+
+# ---------------------------------------------------------------------------
+# build_body
+# ---------------------------------------------------------------------------
+
+MINIMAL_FINDING = {
+    "id": "SEC-1",
+    "title": "Hardcoded API key",
+    "scope": "Security",
+    "severity": "Critical",
+    "blocking": True,
+    "where": "config.py:42",
+    "what": "API key stored in plaintext",
+    "proof": "grep -r 'sk-' shows key at line 42",
+    "impact": "Full API access to attacker",
+    "fix": "Move to environment variable",
+    "batch": 1,
+}
+
+
+class TestBuildBody:
+    def test_includes_id_and_title(self):
+        body = build_body(MINIMAL_FINDING)
+        assert "SEC-1" in body
+        assert "Hardcoded API key" in body
+
+    def test_includes_scope_and_severity(self):
+        body = build_body(MINIMAL_FINDING)
+        assert "Security" in body
+        assert "Critical" in body
+
+    def test_blocking_yes_when_true(self):
+        body = build_body(MINIMAL_FINDING)
+        assert "**Blocking:** Yes" in body
+
+    def test_blocking_no_when_false(self):
+        f = {**MINIMAL_FINDING, "blocking": False}
+        body = build_body(f)
+        assert "**Blocking:** No" in body
+
+    def test_where_in_code_block(self):
+        body = build_body(MINIMAL_FINDING)
+        assert "`config.py:42`" in body
+
+    def test_fix_included(self):
+        body = build_body(MINIMAL_FINDING)
+        assert "Move to environment variable" in body
+
+    def test_footer_attribution(self):
+        body = build_body(MINIMAL_FINDING)
+        assert "Filed by harden-issues.py" in body
+
+    def test_optional_fields_missing_no_keyerror(self):
+        sparse = {
+            "id": "AI-1",
+            "title": "Sparse finding",
+            "scope": "AI",
+            "severity": "Low",
+            "blocking": False,
+            "where": "foo.py:1",
+            "what": "something",
+            "fix": "fix it",
+            "batch": 1,
+        }
+        body = build_body(sparse)  # no proof or impact
+        assert "AI-1" in body
+
+
+# ---------------------------------------------------------------------------
+# create_issue — dry run
+# ---------------------------------------------------------------------------
+
+
+class TestCreateIssueDryRun:
+    def test_dry_run_does_not_call_subprocess(self, capsys):
+        with patch("subprocess.run") as mock_run:
+            create_issue(MINIMAL_FINDING, repo="owner/repo", batch=1, dry_run=True)
+            mock_run.assert_not_called()
+
+    def test_dry_run_prints_title(self, capsys):
+        create_issue(MINIMAL_FINDING, repo="owner/repo", batch=1, dry_run=True)
+        out = capsys.readouterr().out
+        assert "[dry-run]" in out
+        assert "SEC-1" in out
+
+    def test_live_run_builds_correct_gh_cmd(self, capsys):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "https://github.com/owner/repo/issues/1"
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            create_issue(MINIMAL_FINDING, repo="owner/repo", batch=1, dry_run=False)
+            args, kwargs = mock_run.call_args
+            cmd = args[0]
+            assert cmd[0] == "gh"
+            assert "issue" in cmd
+            assert "create" in cmd
+            assert "--repo" in cmd
+            assert "owner/repo" in cmd
+            assert "--label" in cmd
+
+    def test_live_run_includes_blocking_label(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            create_issue(MINIMAL_FINDING, repo="owner/repo", batch=1, dry_run=False)
+            cmd = mock_run.call_args[0][0]
+            label_idx = cmd.index("--label") + 1
+            labels = cmd[label_idx]
+            assert "blocking" in labels
+            assert "critical" in labels
+
+    def test_live_run_no_blocking_label_when_false(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        f = {**MINIMAL_FINDING, "blocking": False}
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            create_issue(f, repo="owner/repo", batch=1, dry_run=False)
+            cmd = mock_run.call_args[0][0]
+            label_idx = cmd.index("--label") + 1
+            labels = cmd[label_idx]
+            assert "blocking" not in labels
+
+
+# ---------------------------------------------------------------------------
+# validate_findings
+# ---------------------------------------------------------------------------
+
+
+class TestValidateFindings:
+    def test_valid_finding_no_errors(self):
+        errors = validate_findings([MINIMAL_FINDING])
+        assert errors == []
+
+    def test_missing_required_field(self):
+        bad = {k: v for k, v in MINIMAL_FINDING.items() if k != "fix"}
+        errors = validate_findings([bad])
+        assert any("fix" in e for e in errors)
+
+    def test_invalid_severity_reported(self):
+        bad = {**MINIMAL_FINDING, "severity": "urgent"}
+        errors = validate_findings([bad])
+        assert any("invalid severity" in e for e in errors)
+
+    def test_multiple_missing_fields(self):
+        bad = {"id": "X-1", "title": "x", "scope": "Security"}
+        errors = validate_findings([bad])
+        # at least severity, blocking, where, what, fix, batch are missing
+        assert len(errors) >= 2
+
+    def test_empty_list_no_errors(self):
+        assert validate_findings([]) == []

--- a/skills/harden/validate_findings.py
+++ b/skills/harden/validate_findings.py
@@ -13,8 +13,7 @@ import json
 import sys
 from pathlib import Path
 
-VALID_SEVERITIES = {"critical", "high", "medium", "low"}
-REQUIRED_FIELDS = ("scope", "severity", "blocking")
+from schema import REQUIRED_FIELDS, VALID_SEVERITIES
 
 
 def validate(findings: list[dict]) -> list[str]:


### PR DESCRIPTION
## Summary

- **#154 (AI-1):** Added explicit scope restriction to the background agent prompt in `SKILL.md` — agent may only write to `findings.json`, not any MARVIN state files
- **#155 (INFRA-1):** `capture_tokens.py` — added `--verbose` flag (prints project_dir, JSONL paths, mtimes), `--project-dir` override (bypasses cwd-based computation), and a 2-hour time-based JSONL fallback so token capture no longer silently fails
- **#156 (QUAL-1):** Extracted `schema.py` with a single `REQUIRED_FIELDS` + `VALID_SEVERITIES` definition; both `validate_findings.py` and `harden-issues.py` import from it — eliminates the 3-field vs 9-field divergence
- **#157 (TEST-1):** Added `tests/test_harden_issues.py` (18 tests) covering `build_body` field interpolation, `create_issue` dry-run and live subprocess command construction, and `validate_findings` error paths; extracted `validate_findings()` from `main()` to make it testable

## Test plan

- [x] `uv run pytest tests/` — 40/40 passing (18 new + 22 existing)
- [x] Ruff lint clean

Closes #154, #155, #156, #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)