### PR TITLE
fix(slack-bot): increase Claude timeout from 2 min to 5 min

### DIFF
--- a/integrations/slack/bot.py
+++ b/integrations/slack/bot.py
@@ -53,7 +53,7 @@ def _is_authorized(user_id: str) -> bool:
 
 
 MARVIN_DIR = str(Path.home() / "marvin")
-CLAUDE_TIMEOUT = 120  # seconds
+CLAUDE_TIMEOUT = 300  # seconds
 MAX_INPUT_LENGTH = 4000  # Slack's own message limit
 SYSTEM_PROMPT = (
     "You are MARVIN, an AI Chief of Staff running inside Claude Code. "
@@ -307,7 +307,7 @@ def ask_claude(prompt: str, thread_key: str) -> str:
                 return output
 
             except subprocess.TimeoutExpired:
-                return "That took too long (>2 min). Try a simpler question."
+                return "That took too long (>5 min). Try a simpler question."
             except FileNotFoundError:
                 return "Error: `claude` CLI not found. Make sure Claude Code is installed."
             except Exception:

--- a/integrations/slack/tests/test_bot_core.py
+++ b/integrations/slack/tests/test_bot_core.py
@@ -318,7 +318,7 @@ class TestAskClaude:
 
         proc = subprocess.run(
             ["claude", "--print", "--output-format", "json", "hello"],
-            capture_output=True, text=True, timeout=120,
+            capture_output=True, text=True, timeout=300,
         )
         output = proc.stdout.strip()
         data = json.loads(output)
@@ -335,7 +335,7 @@ class TestAskClaude:
         existing_session = "abc-123"
 
         cmd = ["claude", "--print", "--resume", existing_session, "follow up"]
-        subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        subprocess.run(cmd, capture_output=True, text=True, timeout=300)
 
         called_cmd = mock_run.call_args[0][0]
         assert "--resume" in called_cmd
@@ -348,7 +348,7 @@ class TestAskClaude:
 
         proc = subprocess.run(
             ["claude", "--print", "hello"],
-            capture_output=True, text=True, timeout=120,
+            capture_output=True, text=True, timeout=300,
         )
         output = proc.stdout.strip()
         assert output == ""
@@ -357,12 +357,12 @@ class TestAskClaude:
     @patch("subprocess.run")
     def test_timeout_raises_exception(self, mock_run):
         """subprocess.TimeoutExpired should propagate so caller can handle it."""
-        mock_run.side_effect = subprocess.TimeoutExpired(cmd="claude", timeout=120)
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="claude", timeout=300)
 
         with pytest.raises(subprocess.TimeoutExpired):
             subprocess.run(
                 ["claude", "--print", "hello"],
-                capture_output=True, text=True, timeout=120,
+                capture_output=True, text=True, timeout=300,
             )
 
     @patch("subprocess.run")
@@ -372,7 +372,7 @@ class TestAskClaude:
 
         proc = subprocess.run(
             ["claude", "--print", "--output-format", "json", "hello"],
-            capture_output=True, text=True, timeout=120,
+            capture_output=True, text=True, timeout=300,
         )
         output = proc.stdout.strip()
         try:
@@ -392,7 +392,7 @@ class TestAskClaude:
 
         proc = subprocess.run(
             ["claude", "--print", "--resume", "abc", "hello"],
-            capture_output=True, text=True, timeout=120,
+            capture_output=True, text=True, timeout=300,
         )
         output = proc.stdout.strip()
         is_conflict = "Session ID" in output and "is already in use" in output
@@ -413,14 +413,14 @@ class TestAskClaude:
         max_retries = 2
         output = None
         for attempt in range(max_retries + 1):
-            proc = subprocess.run(["claude"], capture_output=True, text=True, timeout=120)
+            proc = subprocess.run(["claude"], capture_output=True, text=True, timeout=300)
             output = proc.stdout.strip()
             if "Session ID" in output and "is already in use" in output:
                 if attempt < max_retries:
                     continue
                 # Clear session and start fresh
                 sessions.pop("thread1", None)
-                proc = subprocess.run(["claude"], capture_output=True, text=True, timeout=120)
+                proc = subprocess.run(["claude"], capture_output=True, text=True, timeout=300)
                 output = proc.stdout.strip()
                 data = json.loads(output)
                 if data.get("session_id"):
@@ -440,5 +440,5 @@ class TestAskClaude:
         with pytest.raises(FileNotFoundError):
             subprocess.run(
                 ["claude", "--print", "hello"],
-                capture_output=True, text=True, timeout=120,
+                capture_output=True, text=True, timeout=300,
             )


### PR DESCRIPTION
## Summary

- `CLAUDE_TIMEOUT` increased from `120` → `300` seconds in `bot.py`
- Timeout error message updated from ">2 min" to ">5 min"
- All `timeout=120` references in tests updated to `timeout=300`

## Test plan

- [x] 86 tests pass: `uv run pytest integrations/slack/tests/ -q`

Closes https://github.com/MatthewDruhl/marvin/issues/180

🤖 Generated with [Claude Code](https://claude.com/claude-code)