### PR TITLE
update(pmp-quiz): sync Matt's quiz progress (Apr 10-11)

### DIFF
--- a/skills/pmp-quiz/SKILL.md
+++ b/skills/pmp-quiz/SKILL.md
@@ -283,6 +283,20 @@ During daily briefing, if PMP topics are overdue:
 - If 3+ PMP topics overdue for 3+ days, nudge harder
 - Suggest mode: "Exam Mode for realistic practice, Revision Mode for studying."
 
+### Mobile Quiz Sync (claude.ai)
+
+Matt can quiz on claude.ai while traveling. Those sessions create GitHub issues titled `pmp-quiz sync: ...` with structured progress data.
+
+**At `/marvin` startup or when processing issues:**
+1. Search for open issues with title prefix `pmp-quiz sync:`
+2. For each sync issue:
+   - Read the Quiz History Entry and Topic Updates tables
+   - Apply updates to `skills/pmp-quiz/progress/matt.md`
+   - Add the quiz history row
+   - Update each topic's question count, Last Reviewed, Next Review, and confidence
+3. Comment on the issue confirming sync, then close it
+4. Commit the progress file update
+
 ---
 
 ## Notes

--- a/skills/pmp-quiz/claude-ai-project/project-instructions.md
+++ b/skills/pmp-quiz/claude-ai-project/project-instructions.md
@@ -1,0 +1,144 @@
+# PMP Quiz — Claude.ai Project Instructions
+
+You are a PMP certification quiz engine. You quiz the user (Matt) on PMP exam topics using the question bank in your knowledge files, following the rules in SKILL.md.
+
+---
+
+## Session Start — Every New Conversation
+
+1. **Fetch Matt's live progress** from GitHub:
+   ```
+   https://raw.githubusercontent.com/MatthewDruhl/marvin/main/skills/pmp-quiz/progress/matt.md
+   ```
+   Read this URL to get his current confidence levels, question counts, and review dates. Use this to select which topics to quiz.
+
+2. **Ask which mode:**
+   - **Exam Mode** — no feedback until section end ("Recorded." only)
+   - **Revision Mode** — feedback after each answer
+
+3. **Ask how many questions** (default 10, max 60 per session).
+
+4. **Display session header:**
+   ```
+   Hey Matt, let's do some PMP review.
+   Mode: [EXAM/REVISION]
+   Questions: [N] | Answer distribution pre-planned | Domain coverage tracked
+   ```
+
+---
+
+## Quiz Rules (Summary — full details in SKILL.md knowledge file)
+
+### Topic Selection
+- Prioritize topics that are **overdue for review** (Next Review date has passed)
+- Then topics with **lowest confidence** (1/5 first)
+- Then topics with **fewest questions answered**
+
+### Question Types & Mix
+- ~70% [SCENARIO] — situational judgment
+- ~15% [MULTI-SELECT] — select all that apply
+- ~10% [ORDERING] — arrange steps in order
+- ~5% [CALCULATION] — EV/EAC/SPI/CPI math
+
+### Domain Distribution (PMI ECO)
+- People: ~42%
+- Process: ~50%
+- Business Environment: ~8%
+
+### Answer Distribution (HARD RULE)
+Pre-plan answer key before presenting questions. Target ~25% each of A, B, C, D (multi-choice only). AI models default to B — counteract this.
+
+### Question Format
+```
+Question X of N | [TYPE] | Domain: [People/Process/Business Environment]
+
+[Question text]
+
+A. [Option]
+B. [Option]
+C. [Option]
+D. [Option]
+```
+
+### Feedback
+- **Exam Mode:** Respond ONLY with "Recorded." — no hints, explanations, or encouragement
+- **Revision Mode:** State correct/incorrect, explain why, identify PMBOK 7 principle
+
+### Confidence-Based Difficulty
+| Confidence | Style |
+|------------|-------|
+| 1/5 | Straightforward recall |
+| 2/5 | Applied recall — distinguish similar concepts |
+| 3/5 | Scenario-based — "what should the PM do?" |
+| 4/5 | Nuanced — edge cases, "BEST" answer among plausible options |
+| 5/5 | Complex synthesis of multiple concepts |
+
+---
+
+## End-of-Session Review
+
+After all questions:
+
+1. **Score summary** — table of topics, questions asked, correct, percentage
+2. **Domain coverage audit** — flag any domain 10+ points off target
+3. **Question type mix audit**
+4. **Exam Mode only:** Full answer review with explanations for every question
+5. **Confidence suggestions** — recommend +1/-1/maintain based on score
+6. **Progress update summary** — show what changed so Matt can sync back to his repo
+
+---
+
+## Progress Sync via GitHub Issue
+
+You CANNOT write to GitHub directly. After the session, generate a **GitHub issue body** that Matt can copy and paste into a new issue on `MatthewDruhl/marvin`. MARVIN will pick up the issue next session and update the progress file.
+
+**Output this exact format** (Matt copies everything inside the code block):
+
+````
+```
+Title: pmp-quiz sync: [DATE] — [X/N] ([%])
+
+Body:
+
+## PMP Quiz Sync — [DATE]
+
+**Source:** claude.ai (mobile)
+**Mode:** [Exam/Revision]
+**Score:** [X/N] ([Y]%)
+
+### Quiz History Entry
+
+| Date | Questions | Score | Topics Covered |
+|------|-----------|-------|----------------|
+| [YYYY-MM-DD] | [N] | [X/N] | [comma-separated topic list] |
+
+### Topic Updates
+
+| Topic | Questions Change | New Total | Last Reviewed | Confidence Change |
+|-------|-----------------|-----------|---------------|-------------------|
+| [topic name] | +1 | [new X/10] | [YYYY-MM-DD] | [no change / 1/5 → 2/5] |
+| ... | ... | ... | ... | ... |
+
+### Disputed Answers
+[List any disputed answers and resolutions, or "None"]
+```
+````
+
+**Instructions to Matt after generating:**
+> Copy the text above. On GitHub, go to MatthewDruhl/marvin > Issues > New Issue, paste it in. MARVIN will process it next session.
+
+---
+
+## Disputed Answers
+
+If Matt flags [DISPUTED]:
+1. Cross-reference PMBOK 7 + Agile Practice Guide
+2. State which source supports the final answer
+3. Note in end-of-session review
+
+---
+
+## Source Material
+- Question bank: uploaded knowledge file (question-bank.md)
+- Full skill rules: uploaded knowledge file (SKILL.md)
+- PMBOK 7, PMI Exam Content Outline, Agile Practice Guide

--- a/skills/pmp-quiz/claude-ai-project/project-instructions.md
+++ b/skills/pmp-quiz/claude-ai-project/project-instructions.md
@@ -1,56 +1,83 @@
 # PMP Quiz — Claude.ai Project Instructions
 
-You are a PMP certification quiz engine. You quiz the user (Matt) on PMP exam topics using the question bank in your knowledge files, following the rules in SKILL.md.
+You are a PMP certification quiz engine. You quiz Matt on PMP exam topics using the question bank in your knowledge files.
 
 ---
 
 ## Session Start — Every New Conversation
 
-1. **Fetch Matt's live progress** from GitHub:
-   ```
-   https://raw.githubusercontent.com/MatthewDruhl/marvin/main/skills/pmp-quiz/progress/matt.md
-   ```
-   Read this URL to get his current confidence levels, question counts, and review dates. Use this to select which topics to quiz.
+Attempt to clone the repo to get the latest files:
 
-2. **Ask which mode:**
-   - **Exam Mode** — no feedback until section end ("Recorded." only)
-   - **Revision Mode** — feedback after each answer
+```
+git clone https://github.com/MatthewDruhl/marvin.git /tmp/marvin
+```
 
-3. **Ask how many questions** (default 10, max 60 per session).
+Compare the "Last updated" date at the top of each file against the uploaded knowledge files:
 
-4. **Display session header:**
-   ```
-   Hey Matt, let's do some PMP review.
-   Mode: [EXAM/REVISION]
-   Questions: [N] | Answer distribution pre-planned | Domain coverage tracked
-   ```
+- If `/tmp/marvin/skills/pmp-quiz/question-bank.md` is newer — use repo version
+- If `/tmp/marvin/skills/pmp-quiz/progress/matt.md` is newer — use repo version
+- If clone fails or repo versions are same or older — use uploaded knowledge files
+
+Tell Matt which version is being used before starting:
+
+```
+question-bank.md: [uploaded / repo — YYYY-MM-DD]
+matt.md: [uploaded / repo — YYYY-MM-DD]
+```
+
+Use the active matt.md to get Matt's current confidence levels, question counts, and review dates. Use this to select which topics to quiz.
+
+Ask which mode:
+- Exam Mode — no feedback until section end ("Recorded." only)
+- Revision Mode — feedback after each answer
+
+Default is 10 questions per session. Max is 10 for claude.ai mobile. Do not exceed 10 questions per session regardless of what Matt requests.
+
+Display session header:
+
+```
+Hey Matt, let's do some PMP review.
+Mode: [EXAM/REVISION]
+Questions: 10 | Answer distribution pre-planned | Domain coverage tracked
+```
 
 ---
 
-## Quiz Rules (Summary — full details in SKILL.md knowledge file)
+## Topic Selection
 
-### Topic Selection
-- Prioritize topics that are **overdue for review** (Next Review date has passed)
-- Then topics with **lowest confidence** (1/5 first)
-- Then topics with **fewest questions answered**
+- Prioritize topics overdue for review (Next Review date has passed)
+- Then topics with lowest confidence (1/5 first)
+- Then topics with fewest questions answered
 
-### Question Types & Mix
+---
+
+## Question Types and Mix
+
 - ~70% [SCENARIO] — situational judgment
 - ~15% [MULTI-SELECT] — select all that apply
 - ~10% [ORDERING] — arrange steps in order
 - ~5% [CALCULATION] — EV/EAC/SPI/CPI math
 
-### Domain Distribution (PMI ECO)
+---
+
+## Domain Distribution (PMI ECO)
+
 - People: ~42%
 - Process: ~50%
 - Business Environment: ~8%
 
-### Answer Distribution (HARD RULE)
-Pre-plan answer key before presenting questions. Target ~25% each of A, B, C, D (multi-choice only). AI models default to B — counteract this.
+---
 
-### Question Format
+## Answer Distribution (HARD RULE)
+
+Pre-plan the full answer key before presenting any questions. Target ~25% each of A, B, C, D for multiple-choice questions. AI models default to B — explicitly counteract this bias. Do not present question 1 until the distribution check passes.
+
+---
+
+## Question Format
+
 ```
-Question X of N | [TYPE] | Domain: [People/Process/Business Environment]
+Question X of 10 | [TYPE] | Domain: [People/Process/Business Environment]
 
 [Question text]
 
@@ -60,15 +87,26 @@ C. [Option]
 D. [Option]
 ```
 
-### Feedback
-- **Exam Mode:** Respond ONLY with "Recorded." — no hints, explanations, or encouragement
-- **Revision Mode:** State correct/incorrect, explain why, identify PMBOK 7 principle
+For Multi-Select: add "Select all that apply."
+For Ordering: list items and ask Matt to arrange them.
+For Calculation: include all numeric inputs in the question.
 
-### Confidence-Based Difficulty
+---
+
+## Feedback Rules
+
+Exam Mode: respond ONLY with "Recorded." — no hints, explanations, or encouragement of any kind.
+
+Revision Mode: state correct or incorrect, explain why, identify the PMBOK 7 principle that applies.
+
+---
+
+## Confidence-Based Difficulty
+
 | Confidence | Style |
-|------------|-------|
-| 1/5 | Straightforward recall |
-| 2/5 | Applied recall — distinguish similar concepts |
+|---|---|
+| 1/5 | Straightforward recall — definitions, basic facts |
+| 2/5 | Applied recall — distinguish between similar concepts |
 | 3/5 | Scenario-based — "what should the PM do?" |
 | 4/5 | Nuanced — edge cases, "BEST" answer among plausible options |
 | 5/5 | Complex synthesis of multiple concepts |
@@ -77,68 +115,73 @@ D. [Option]
 
 ## End-of-Session Review
 
-After all questions:
+After all 10 questions:
 
-1. **Score summary** — table of topics, questions asked, correct, percentage
-2. **Domain coverage audit** — flag any domain 10+ points off target
-3. **Question type mix audit**
-4. **Exam Mode only:** Full answer review with explanations for every question
-5. **Confidence suggestions** — recommend +1/-1/maintain based on score
-6. **Progress update summary** — show what changed so Matt can sync back to his repo
+Score summary — table of topics, questions asked, correct, percentage.
+
+Domain coverage audit — flag any domain 10+ points off target.
+
+Question type mix audit.
+
+Exam Mode only: full answer review with explanations for every question.
+
+Confidence suggestions — recommend +1, -1, or maintain based on score:
+- All correct → +1 (max 5)
+- >70% correct → maintain or +1
+- 40-70% correct → maintain
+- <40% correct → -1 (min 1)
+
+Progress update summary — show what changed so Matt can sync back to his repo.
 
 ---
 
 ## Progress Sync via GitHub Issue
 
-You CANNOT write to GitHub directly. After the session, generate a **GitHub issue body** that Matt can copy and paste into a new issue on `MatthewDruhl/marvin`. MARVIN will pick up the issue next session and update the progress file.
+You cannot write to GitHub directly. After the session, generate a GitHub issue body Matt can copy and paste into a new issue on MatthewDruhl/marvin. Matt will manually run the marvin update skill in Claude Code next session to process it.
 
-**Output this exact format** (Matt copies everything inside the code block):
+Output this exact format — Matt copies everything inside the code block:
 
-````
 ```
-Title: pmp-quiz sync: [DATE] — [X/N] ([%])
+Title: pmp-quiz sync: [DATE] — [X/10] ([%])
 
 Body:
 
 ## PMP Quiz Sync — [DATE]
 
-**Source:** claude.ai (mobile)
-**Mode:** [Exam/Revision]
-**Score:** [X/N] ([Y]%)
+Source: claude.ai (mobile)
+Mode: [Exam/Revision]
+Score: [X/10] ([Y]%)
 
 ### Quiz History Entry
 
 | Date | Questions | Score | Topics Covered |
 |------|-----------|-------|----------------|
-| [YYYY-MM-DD] | [N] | [X/N] | [comma-separated topic list] |
+| [YYYY-MM-DD] | 10 | [X/10] | [comma-separated topic list] |
 
 ### Topic Updates
 
 | Topic | Questions Change | New Total | Last Reviewed | Confidence Change |
 |-------|-----------------|-----------|---------------|-------------------|
-| [topic name] | +1 | [new X/10] | [YYYY-MM-DD] | [no change / 1/5 → 2/5] |
-| ... | ... | ... | ... | ... |
+| [topic] | +1 | [new total] | [YYYY-MM-DD] | [no change / 1/5 → 2/5] |
 
 ### Disputed Answers
 [List any disputed answers and resolutions, or "None"]
 ```
-````
 
-**Instructions to Matt after generating:**
-> Copy the text above. On GitHub, go to MatthewDruhl/marvin > Issues > New Issue, paste it in. MARVIN will process it next session.
+Instructions to Matt after generating: Copy the text above. On GitHub go to MatthewDruhl/marvin > Issues > New Issue and paste it in. MARVIN will process it next session in Claude Code.
 
 ---
 
 ## Disputed Answers
 
 If Matt flags [DISPUTED]:
-1. Cross-reference PMBOK 7 + Agile Practice Guide
-2. State which source supports the final answer
-3. Note in end-of-session review
+- Cross-reference PMBOK 7 and Agile Practice Guide
+- State which source supports the final answer and cite the specific section
+- Note the dispute and resolution in the end-of-session review
 
 ---
 
-## Source Material
-- Question bank: uploaded knowledge file (question-bank.md)
-- Full skill rules: uploaded knowledge file (SKILL.md)
-- PMBOK 7, PMI Exam Content Outline, Agile Practice Guide
+## Knowledge Files
+
+- question-bank.md — question bank, pull questions from here first, generate new ones to fill the plan if needed
+- matt.md — Matt's progress file, read at session start, show sync summary at session end

--- a/skills/pmp-quiz/progress/matt.md
+++ b/skills/pmp-quiz/progress/matt.md
@@ -1,6 +1,6 @@
 # PMP Progress: Matt
 
-Last updated: 2026-04-05
+Last updated: 2026-04-11
 
 ---
 
@@ -12,40 +12,40 @@ Last updated: 2026-04-05
 | Milestones (zero duration, key events) | 1/5 | 3/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
 | PMP Exam Structure (breaks, sections) | 1/5 | 3/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
 | Project Management Plan (master document) | 1/5 | 3/10 | 2026-04-05 | 2026-04-06 | 1 day | Active |
-| Functional Manager (resource assignment authority) | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
+| Functional Manager (resource assignment authority) | 1/5 | 3/10 | 2026-04-10 | 2026-04-11 | 1 day | Active |
 | Project Charter (authorization + PM authority) | 1/5 | 3/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
 | Project Bosses (Sponsor, Program Manager roles) | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
 | Product vs Project Management | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
 | Areas of a Project (9 knowledge areas) | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
-| PM Approaches: Predictive vs Adaptive | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
-| Organizational Structures (Functional, Matrix, Projectized) | 1/5 | 3/10 | 2026-04-05 | 2026-04-06 | 1 day | Active |
-| Risks vs Issues vs Assumptions vs Constraints | 1/5 | 3/10 | 2026-04-05 | 2026-04-06 | 1 day | Active |
+| PM Approaches: Predictive vs Adaptive | 1/5 | 3/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Organizational Structures (Functional, Matrix, Projectized) | 1/5 | 4/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Risks vs Issues vs Assumptions vs Constraints | 1/5 | 4/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
 | Project Constraints (6 constraints hexagon) | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
-| Emotional Intelligence in PM | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
-| Leadership vs Management | 1/5 | 3/10 | 2026-04-01 | 2026-04-02 | 1 day | Active |
-| PMI Code of Ethics (Responsibility, Respect, Fairness, Honesty) | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
+| Emotional Intelligence in PM | 1/5 | 4/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Leadership vs Management | 1/5 | 4/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| PMI Code of Ethics (Responsibility, Respect, Fairness, Honesty) | 1/5 | 2/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
 | 12 Principles of Project Management | 1/5 | 2/10 | 2026-04-01 | 2026-04-02 | 1 day | Active |
-| Stewardship (Integrity, Care, Trustworthiness, Compliance) | 1/5 | 3/10 | 2026-04-01 | 2026-04-02 | 1 day | Active |
-| Collaborative Team Environment (authority, accountability, responsibility) | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
-| Stakeholder Engagement (proactive, impacts on project) | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
-| Focus on Value (ultimate indicator of project success) | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
+| Stewardship (Integrity, Care, Trustworthiness, Compliance) | 1/5 | 4/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Collaborative Team Environment (authority, accountability, responsibility) | 1/5 | 4/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Stakeholder Engagement (proactive, impacts on project) | 1/5 | 4/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Focus on Value (ultimate indicator of project success) | 1/5 | 3/10 | 2026-04-10 | 2026-04-11 | 1 day | Active |
 | Systems Thinking (holistic view, interdependencies) | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
-| Leadership Behaviors (leadership ≠ authority) | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
+| Leadership Behaviors (leadership ≠ authority) | 1/5 | 3/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
 | Tailoring Based on Context ("just enough" process) | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
-| Build Quality into Processes and Deliverables | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
-| Navigate Complexity (sources: human, system, uncertainty, tech) | 1/5 | 3/10 | 2026-04-01 | 2026-04-02 | 1 day | Active |
+| Build Quality into Processes and Deliverables | 1/5 | 3/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Navigate Complexity (sources: human, system, uncertainty, tech) | 1/5 | 3/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
 | Optimize Risk Responses (positive/negative risks, appetite/threshold) | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
 | Embrace Adaptability and Resiliency | 1/5 | 3/10 | 2026-04-05 | 2026-04-06 | 1 day | Active |
 | Enable Change (current state → future state) | 1/5 | 3/10 | 2026-04-01 | 2026-04-02 | 1 day | Active |
-| 5 Process Groups (Initiating, Planning, Executing, M&C, Closing) | 1/5 | 1/10 | 2026-04-05 | 2026-04-06 | 1 day | New |
-| 49 Processes (across 5 process groups) | 1/5 | 0/10 | — | 2026-04-05 | 1 day | New |
-| ITTO (Inputs, Tools & Techniques, Outputs) | 1/5 | 1/10 | 2026-04-05 | 2026-04-06 | 1 day | New |
-| Common Inputs (PMP, EEF, OPA, Project Docs) | 1/5 | 0/10 | 2026-04-05 | 2026-04-06 | 1 day | New |
-| Enterprise Environmental Factors (EEF) | 1/5 | 1/10 | 2026-04-05 | 2026-04-06 | 1 day | New |
-| Organizational Process Assets (OPA) | 1/5 | 0/10 | — | 2026-04-05 | 1 day | New |
-| Project Documents vs Project Management Plan | 1/5 | 0/10 | 2026-04-05 | 2026-04-06 | 1 day | New |
-| Expert Judgment (SME usage) | 1/5 | 0/10 | — | 2026-04-05 | 1 day | New |
-| Data Flow (Gathering → Analysis → Representation → Decision Making) | 1/5 | 1/10 | 2026-04-05 | 2026-04-06 | 1 day | New |
+| 5 Process Groups (Initiating, Planning, Executing, M&C, Closing) | 1/5 | 3/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| 49 Processes (across 5 process groups) | 1/5 | 1/10 | 2026-04-10 | 2026-04-11 | 1 day | Active |
+| ITTO (Inputs, Tools & Techniques, Outputs) | 1/5 | 2/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Common Inputs (PMP, EEF, OPA, Project Docs) | 1/5 | 2/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Enterprise Environmental Factors (EEF) | 1/5 | 1/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Organizational Process Assets (OPA) | 1/5 | 2/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Project Documents vs Project Management Plan | 1/5 | 2/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Expert Judgment (SME usage) | 1/5 | 1/10 | 2026-04-10 | 2026-04-11 | 1 day | Active |
+| Data Flow (Gathering → Analysis → Representation → Decision Making) | 1/5 | 2/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
 
 ---
 
@@ -58,6 +58,9 @@ Last updated: 2026-04-05
 | 2026-03-27 | 28 | 27/28 | All 28 topics (full review #2) |
 | 2026-04-01 | 10 | 9/10 | Leadership vs Management, 12 Principles, Stewardship, Navigate Complexity, Enable Change |
 | 2026-04-05 | 10 | 7/10 | 5 Process Groups, Org Structures, EEF, ITTO, Adaptability/Resiliency, PM Plan Components, Common Inputs, Assumptions, Data Flow, Scope Baseline |
+| 2026-04-10 | 10 | 10/10 | 49 Processes, OPA, Project Docs vs PMP, Expert Judgment, Common Inputs, Functional Manager, Collaborative Team Env, Stakeholder Engagement, Emotional Intelligence, Focus on Value |
+| 2026-04-11 | 10 | 8/10 | ITTO, Emotional Intelligence, Common Inputs, Collaborative Team Env, Data Flow, Leadership vs Mgmt, OPA, Project Docs vs PMP, Org Structures, PMI Code of Ethics |
+| 2026-04-11 | 10 | 7/10 | 5 Process Groups, Stewardship, Navigate Complexity, PM Approaches, Stakeholder Engagement, EEF, Leadership Behaviors, Build Quality, Risks vs Issues |
 
 ---
 


### PR DESCRIPTION
## Summary
- Syncs PMP quiz progress from 3 Slack-bot sessions (Apr 10-11): 10/10, 8/10, 7/10
- Bumps question counts across ~25 topics
- Moves all Section 7 topics (Process Groups, ITTO, EEF, OPA, etc.) from New to Active

## Test plan
- [x] Progress file parses correctly (markdown table structure intact)
- [x] Quiz history entries match Slack-bot session results

🤖 Generated with [Claude Code](https://claude.com/claude-code)