### PR TITLE
fix(youtube-transcribe): output isolation, gitignore, command dedup

### DIFF
--- a/.claude/commands/youtube-transcribe.md
+++ b/.claude/commands/youtube-transcribe.md
@@ -2,20 +2,10 @@
 description: Download and clean a YouTube transcript from a video URL
 ---
 
-# /youtube-transcribe
-
-Download auto-generated subtitles from a YouTube video and strip SRT formatting to produce a clean plain-text transcript.
-
-## Instructions
-
 The user has provided a YouTube URL: `$ARGUMENTS`
-
-Run the transcribe script:
 
 ```bash
 bash skills/youtube-transcribe/transcribe.sh "$ARGUMENTS"
 ```
 
-After it completes:
-1. Confirm `transcript.txt` was created
-2. Ask if the user wants to view the contents or have the video summarized
+Follow `skills/youtube-transcribe/SKILL.md` for post-processing steps.

--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,6 @@ uv.lock
 harden_*_token_usage.csv
 
 # youtube-transcribe skill output
+content/transcripts/
 transcript.txt
 transcript*.srt

--- a/skills/youtube-transcribe/SKILL.md
+++ b/skills/youtube-transcribe/SKILL.md
@@ -33,19 +33,20 @@ bash skills/youtube-transcribe/transcribe.sh "<url>"
 ```
 
 This runs two commands:
-1. `yt-dlp` downloads the auto-generated subtitles as `transcript.en.srt`
-2. `sed` strips sequence numbers, timestamps, and blank lines → `transcript.txt`
+1. `yt-dlp` downloads the auto-generated subtitles to `content/transcripts/`
+2. `sed` strips sequence numbers, timestamps, and blank lines → `transcript_VIDEO_ID.txt`
 
 ### Step 2: Confirm output
 
 Tell the user:
-- Where the transcript was saved (`transcript.txt` in the current directory)
+- Where the transcript was saved (path printed by the script, under `content/transcripts/`)
 - Offer to display the contents or summarize the video
 
 ## Output
 
-- `transcript.en.srt` — raw subtitle file (intermediate, can discard)
-- `transcript.txt` — clean plain-text transcript
+Files are written to `content/transcripts/` with video-ID-based filenames:
+- `transcript_VIDEO_ID.en.srt` — raw subtitle file (intermediate, can discard)
+- `transcript_VIDEO_ID.txt` — clean plain-text transcript
 
 ## Notes
 

--- a/skills/youtube-transcribe/transcribe.sh
+++ b/skills/youtube-transcribe/transcribe.sh
@@ -23,17 +23,33 @@ if ! command -v yt-dlp &>/dev/null; then
     exit 1
 fi
 
+# DEC-1: Output to dedicated directory instead of CWD
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+OUTPUT_DIR="$REPO_ROOT/content/transcripts"
+mkdir -p "$OUTPUT_DIR"
+
+# SEC-2: Derive unique filename from video ID to avoid overwrites
+if [[ "$URL" =~ [?&]v=([a-zA-Z0-9_-]+) ]]; then
+    VIDEO_ID="${BASH_REMATCH[1]}"
+elif [[ "$URL" =~ youtu\.be/([a-zA-Z0-9_-]+) ]]; then
+    VIDEO_ID="${BASH_REMATCH[1]}"
+else
+    VIDEO_ID="$(date +%Y%m%d_%H%M%S)"
+fi
+
 echo "Downloading transcript for: $URL"
-yt-dlp --write-auto-sub --sub-format srt --sub-lang en --skip-download --output "transcript" "$URL"
+yt-dlp --write-auto-sub --sub-format srt --sub-lang en --skip-download --output "$OUTPUT_DIR/transcript_${VIDEO_ID}" "$URL"
 
 # CQ-1: Find the actual SRT file (name may vary)
-SRT_FILE=$(ls transcript*.srt 2>/dev/null | head -1)
+SRT_FILE=$(ls "$OUTPUT_DIR"/transcript_${VIDEO_ID}*.srt 2>/dev/null | head -1)
 if [[ -z "$SRT_FILE" ]]; then
     echo "No subtitle file found. The video may not have English subtitles." >&2
     exit 1
 fi
 
+OUTPUT_FILE="$OUTPUT_DIR/transcript_${VIDEO_ID}.txt"
 echo "Cleaning SRT formatting..."
-sed '/^[0-9]*$/d; /^[0-9:,]* --> /d; /^$/d' "$SRT_FILE" > transcript.txt
+sed '/^[0-9]*$/d; /^[0-9:,]* --> /d; /^$/d' "$SRT_FILE" > "$OUTPUT_FILE"
 
-echo "Done. Transcript saved to: transcript.txt"
+echo "Done. Transcript saved to: $OUTPUT_FILE"


### PR DESCRIPTION
## Summary
- Output files now written to `content/transcripts/` with video-ID-based filenames instead of CWD (#192, #187)
- Added `content/transcripts/` to `.gitignore` (#193)
- Thinned `.claude/commands/youtube-transcribe.md` to minimal wrapper delegating to SKILL.md (#194)

Closes #187, #192, #193, #194

## Test plan
- [ ] Run `/youtube-transcribe` with a YouTube URL — verify output lands in `content/transcripts/transcript_VIDEO_ID.txt`
- [ ] Run again with same URL — verify unique filename (no overwrite)
- [ ] Verify `content/transcripts/` doesn't show in `git status`
- [ ] Verify `/youtube-transcribe` still triggers post-processing from SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)