### PR TITLE
feat(pmp-quiz): /pmp-consume skill + refresher mode + 87 questions

### DIFF
--- a/.claude/commands/pmp-consume.md
+++ b/.claude/commands/pmp-consume.md
@@ -1,0 +1,35 @@
+---
+description: Consume PMP video transcripts and generate quiz questions
+---
+
+# /pmp-consume - PMP Transcript Consumer
+
+Consume unprocessed PMP course video transcripts and generate exam-style questions for the pmp-quiz question bank.
+
+## Instructions
+
+### 1. Load Skill Definition
+
+Read `skills/pmp-quiz/pmp-consume-SKILL.md` for the full process definition.
+
+### 2. Execute the Process
+
+Follow all steps in the SKILL.md:
+
+1. **Discover** — find all unprocessed `*.md` files in `pmp/CourseContent/` (not in `processed/`)
+2. **Read** — read each transcript, extract exam-relevant content
+3. **Generate** — create 5-8 PMP-style questions per transcript (scenario-heavy, use instructor emphasis)
+4. **Write** — append questions to `skills/pmp-quiz/question-bank.md`
+5. **Move** — move consumed files to `pmp/CourseContent/processed/`
+6. **Update** — report new video progress count
+7. **Report** — show consumption summary
+
+### 3. Key Rules
+
+- Process ALL unprocessed files in one run (sorted by video number)
+- Add questions directly to the question bank — no approval step needed
+- Move processed files so they aren't re-read
+- Follow the exact question format from the existing question bank
+- Prioritize scenario-based questions (~50%)
+- Tag each answer with `*(Video N)*` for traceability
+- Writes/appends to `pmp/CourseContent/last-consumed.md` manifest for refresher quiz tracking

--- a/.claude/commands/pmp-quiz.md
+++ b/.claude/commands/pmp-quiz.md
@@ -1,5 +1,5 @@
 ---
-description: PMP quiz - usage /pmp-quiz <name> (Matt or Emily)
+description: PMP quiz - usage /pmp-quiz <name> [exam|revision|refresher] (Matt or Emily)
 ---
 
 # /pmp-quiz - PMP Certification Quiz
@@ -8,16 +8,25 @@ Launch a PMP quiz session for a specific person.
 
 ## Usage
 
-`/pmp-quiz <name>` — where name is `Matt` or `Emily` (case-insensitive)
+`/pmp-quiz <name> [mode] [count]` — where name is `Matt` or `Emily` (case-insensitive)
+
+### Examples
+- `/pmp-quiz Matt exam` — Exam Mode (60 questions, no feedback until end)
+- `/pmp-quiz Matt revision` — Revision Mode (feedback after each answer)
+- `/pmp-quiz Matt refresher` — Refresher Mode (recently consumed content, default 15 questions)
+- `/pmp-quiz Matt refresher 10` — Refresher Mode capped at 10 questions
+- `/pmp-quiz Emily refresher` — works for Emily too
+- `/pmp-quiz Matt` — ask which mode before starting
 
 ## Instructions
 
-### 1. Parse the Argument
+### 1. Parse the Arguments
 
-- Read the argument passed after `/pmp-quiz` (available as `$ARGUMENTS`)
+- Read the arguments passed after `/pmp-quiz` (available as `$ARGUMENTS`)
 - Normalize to lowercase for matching
-- Match against known users: `matt`, `emily`
-- If no argument or unrecognized name: display usage and ask who is quizzing
+- **First argument:** Match against known users: `matt`, `emily`. If no argument or unrecognized name: display usage and ask who is quizzing
+- **Second argument (optional):** Mode — `exam`, `revision`, or `refresher`. If absent, ask which mode.
+- **Third argument (optional, refresher only):** Question count cap (integer). Default is 15 for refresher mode.
 
 ### 2. Load Person's Progress
 

--- a/skills/pmp-quiz/SKILL.md
+++ b/skills/pmp-quiz/SKILL.md
@@ -2,10 +2,11 @@
 name: pmp-quiz
 description: |
   PMP certification quiz skill with per-person progress tracking.
-  Supports Exam Mode (strict simulation) and Revision Mode (learning with feedback).
+  Supports Exam Mode (strict simulation), Revision Mode (learning with feedback),
+  and Refresher Mode (review recently consumed video content).
   Uses Scenario, Multi-Select, Ordering, and Calculation question types.
   Tracks individual confidence ratings and spaced repetition for each person.
-  Invoke: /pmp-quiz <name> [exam|revision] (Matt or Emily, case-insensitive)
+  Invoke: /pmp-quiz <name> [exam|revision|refresher] (Matt or Emily, case-insensitive)
 license: MIT
 compatibility: marvin
 metadata:
@@ -31,8 +32,11 @@ This skill tracks progress independently for each person:
 ### Invocation
 - `/pmp-quiz Matt exam` — quiz Matt in Exam Mode
 - `/pmp-quiz Matt revision` — quiz Matt in Revision Mode
+- `/pmp-quiz Matt refresher` — quiz Matt on recently consumed content (default 15 questions)
+- `/pmp-quiz Matt refresher 10` — refresher mode capped at 10 questions
 - `/pmp-quiz Emily exam` — quiz Emily in Exam Mode
 - `/pmp-quiz Emily revision` — quiz Emily in Revision Mode
+- `/pmp-quiz Emily refresher` — works for Emily too
 - `/pmp-quiz Matt` (no mode) — ask which mode before starting
 - `/pmp-quiz` (no name) — ask who is quizzing, then which mode
 
@@ -60,7 +64,24 @@ Learning mode with immediate feedback after each answer.
 - Encourages understanding, not just recall
 - Suitable for studying and building confidence
 
-**If mode is not specified, ask before starting:** "Which mode — Exam (no feedback until the end) or Revision (feedback after each answer)?"
+### Refresher Mode
+Review recently consumed video content. Immediate feedback after each answer (same as Revision Mode).
+
+- Reads `pmp/CourseContent/last-consumed.md` for the list of unquizzed questions
+- Only presents questions marked `Quizzed?: no` in the manifest
+- Default cap: 15 questions per session. Override with `/pmp-quiz <name> refresher <N>`
+- After each question is answered, mark it `yes` in the manifest's Unquizzed Questions table
+- If no unquizzed questions remain, report: "All refresher questions completed! Run /pmp-consume after watching more videos to add new content."
+- Uses Revision Mode feedback style: state correct/incorrect, provide explanation, identify PMBOK 7 principle
+- At end of session, report how many refresher questions remain unquizzed
+- **Updates the person's progress file** (`skills/pmp-quiz/progress/<name>.md`):
+  - If a topic from the refresher doesn't exist in the progress file, add it at 1/5 confidence, 0/10 questions
+  - Track correct/incorrect answers per topic (increment question count for correct answers)
+  - Update "Last Reviewed" to today for each topic quizzed
+  - Apply the same confidence scoring rules as Revision Mode (>70% correct → maintain or +1, <70% → maintain, <40% → -1)
+  - Add a quiz history row at the end of the session with date, question count, score, and topics covered
+
+**If mode is not specified, ask before starting:** "Which mode — Exam (no feedback until the end), Revision (feedback after each answer), or Refresher (review recently consumed content)?"
 
 ---
 
@@ -158,19 +179,29 @@ If the user believes a question's answer is wrong:
 ### Step 0: Identify Person and Mode
 
 1. Parse the name argument (case-insensitive). If absent, ask: "Who's quizzing? Matt or Emily?"
-2. Parse the mode argument (exam or revision). If absent, ask: "Which mode — Exam (no feedback until the end) or Revision (feedback after each answer)?"
-3. Load their progress file: `skills/pmp-quiz/progress/<name>.md`
-4. Display the session header:
-   ```
-   Hey [Name], let's do some PMP review.
-   Mode: [EXAM MODE — no feedback until section end] or [REVISION MODE — feedback after each answer]
-   Section: 60 questions | Answer distribution pre-planned | Domain coverage tracked
-   ```
-5. Display the context window warning if the user has indicated they want more than 60 questions.
+2. Parse the mode argument (exam, revision, or refresher). If absent, ask: "Which mode — Exam (no feedback until the end), Revision (feedback after each answer), or Refresher (review recently consumed content)?"
+3. For refresher mode: parse optional question count after `refresher` (e.g., `/pmp-quiz Matt refresher 10`). Default cap is 15.
+4. Load their progress file: `skills/pmp-quiz/progress/<name>.md`
+5. Display the session header:
+   - **Exam/Revision:**
+     ```
+     Hey [Name], let's do some PMP review.
+     Mode: [EXAM MODE — no feedback until section end] or [REVISION MODE — feedback after each answer]
+     Section: 60 questions | Answer distribution pre-planned | Domain coverage tracked
+     ```
+   - **Refresher:**
+     ```
+     Hey [Name], let's review your recently consumed content.
+     Mode: REFRESHER — feedback after each answer
+     Questions: up to [N] from last consumed videos
+     ```
+6. Display the context window warning if the user has indicated they want more than 60 questions.
 
 ### Step 1: Pre-Plan the Question Set
 
 Before presenting any questions:
+
+**Exam/Revision Mode:**
 
 1. Select topics based on THIS PERSON's progress file (not `state/learning.md`).
 2. Plan the full 60-question set (or shorter set if fewer requested):
@@ -179,6 +210,15 @@ Before presenting any questions:
    - Assign answer letters: ~25% each of A, B, C, D (for MC questions)
    - Verify all three distributions pass before continuing
 3. Pull questions from `skills/pmp-quiz/question-bank.md` where available; generate new questions to fill the plan.
+
+**Refresher Mode:**
+
+1. Read `pmp/CourseContent/last-consumed.md`
+2. If the file doesn't exist or has no `Quizzed?: no` rows, report: "All refresher questions completed! Run /pmp-consume after watching more videos to add new content." and stop.
+3. Collect all rows where `Quizzed?` is `no`. These are the candidate questions.
+4. Cap at the session limit (default 15, or user-specified N).
+5. Look up each Question ID in the question bank (`skills/pmp-quiz/question-bank.md`) under the matching `### [Topic]` section.
+6. Domain/type distribution rules are relaxed for refresher — present whatever the consumed content produced.
 
 ### Step 2: Ask Questions
 
@@ -210,6 +250,10 @@ Before presenting any questions:
 - Provide a concise explanation.
 - Identify which PMBOK 7 principle or process group applies.
 - For Multi-Select: list all correct answers and explain any the user missed or got wrong.
+
+**Refresher Mode:**
+- Same feedback as Revision Mode: state correct/incorrect, provide explanation, identify PMBOK 7 principle.
+- After evaluating, update `pmp/CourseContent/last-consumed.md` — set `Quizzed?` to `yes` for the question just answered.
 
 ### Step 4: End-of-Section Review (both modes)
 
@@ -268,6 +312,13 @@ After question 60 (or the final question of a shorter session):
 
 7. Do NOT update `state/learning.md` — progress files are the source of truth for this skill.
 
+8. **Refresher Mode only — remaining questions report:**
+   After scoring, read `pmp/CourseContent/last-consumed.md` and count remaining `Quizzed?: no` rows. Report:
+   ```
+   Refresher backlog: [N] questions remaining from consumed videos.
+   ```
+   If none remain: "All refresher questions completed! Run /pmp-consume after watching more videos to add new content."
+
 ### Step 5: Add New Questions (Optional)
 
 If gaps exist in the question bank for certain topics:
@@ -311,4 +362,4 @@ Matt can quiz on claude.ai while traveling. Those sessions create GitHub issues 
 ---
 
 *Skill created: 2026-03-25*
-*Updated: 2026-04-09 — Added Exam/Revision modes, answer distribution enforcement, 60Q hard limit, domain audit, question type mix, zero feedback in exam mode, disputed answer procedure, context window warning*
+*Updated: 2026-04-14 — Added Refresher Mode (review recently consumed video content via manifest tracking)*

--- a/skills/pmp-quiz/pmp-consume-SKILL.md
+++ b/skills/pmp-quiz/pmp-consume-SKILL.md
@@ -1,0 +1,180 @@
+---
+name: pmp-consume
+description: |
+  Consume PMP course video transcripts from pmp/CourseContent/ and generate
+  PMP-style questions added to the pmp-quiz question bank. Tracks processed
+  files to avoid duplicate work. Updates video progress count.
+  Invoke: /pmp-consume
+license: MIT
+compatibility: marvin
+metadata:
+  marvin-category: learning
+  user-invocable: true
+  slash-command: /pmp-consume
+  model: default
+  proactive: false
+---
+
+# PMP Consume — Transcript to Question Bank
+
+Ingest PMP course video transcripts and generate exam-style questions for the pmp-quiz skill.
+
+---
+
+## Source Files
+
+- **Input:** `pmp/CourseContent/*.md` — transcript files named by video number (e.g., `99.md`, `100.md`)
+- **Output:** `skills/pmp-quiz/question-bank.md` — shared question bank
+- **Processed:** `pmp/CourseContent/processed/` — consumed files moved here
+- **Progress:** `skills/pmp-quiz/progress/matt.md` — video count updated
+
+### File Format
+
+Each transcript file contains ONLY the raw transcript from a TIA Education PMP course video. No AI overview, no frontmatter — just the instructor's words.
+
+Files are named by video number: `99.md`, `100.md`, `101.md`, etc.
+
+---
+
+## Process
+
+### Step 1: Discover Unprocessed Files
+
+1. List all `*.md` files in `pmp/CourseContent/` (exclude `processed/` subdirectory)
+2. If no files found, report "No new transcripts to consume." and stop
+3. Sort files by video number (numeric sort on filename)
+4. Report: "Found N unprocessed transcript(s): [list filenames]"
+
+### Step 2: Read and Analyze Each Transcript
+
+For each file, in video number order:
+
+1. Read the full transcript
+2. Identify the **topic(s)** covered (the instructor usually states it at the start)
+3. Extract **exam-relevant content** — focus on:
+   - Definitions and distinctions the instructor emphasizes
+   - Anything the instructor says "remember for your exam" or "I want you to know"
+   - Tricky details, traps, and common misconceptions
+   - Concrete examples and analogies
+   - Process relationships (what feeds into what)
+   - Comparisons and tradeoffs (e.g., crashing vs fast tracking)
+
+### Step 3: Generate Questions
+
+For each transcript, generate **5-8 questions** following the pmp-quiz question types:
+
+| Label | Type | Target % |
+|-------|------|----------|
+| `[SCENARIO]` | Situational judgment — a PM situation, choose best response | ~50% |
+| `[MC]` | Multiple choice — one correct answer from 4 options | ~25% |
+| `[MULTI-SELECT]` | Select all that apply | ~15% |
+| `[ORDERING]` | Arrange steps in correct order | ~10% |
+
+**Question quality rules:**
+
+1. **Scenario questions are king.** The PMP exam is scenario-based. Don't just test definitions — test application. "A PM discovers the schedule is 20 days over. What should they try FIRST?" is better than "What is crashing?"
+2. **Use the instructor's emphasis.** If they said "remember this for your exam," build a question around it.
+3. **Include trap answers.** The PMP exam loves plausible-but-wrong options. Use common misconceptions as distractors.
+4. **Test distinctions.** If the transcript compares two things (crashing vs fast tracking, schedule baseline vs project schedule), test that comparison.
+5. **Match existing format.** Follow the exact format in `skills/pmp-quiz/question-bank.md`:
+   ```
+   **Q[N] - [TYPE]:** [Question]
+   A) ...
+   B) ...
+   C) ...
+   D) ...
+   **A:** [Letter]) [Explanation with exam-relevant context]
+   ```
+6. **Answer distribution.** Across all generated questions per batch, roughly balance A/B/C/D answers.
+7. **Tag the source video.** Add `*(Video [N])*` at the end of each answer explanation so questions are traceable.
+
+### Step 4: Write to Question Bank
+
+1. Read current `skills/pmp-quiz/question-bank.md`
+2. Determine section placement:
+   - Match the transcript topic to an existing `### [Topic]` section if one exists — append questions with incremented Q numbers
+   - If no matching section exists, create a new `### [Topic]` subsection under the appropriate `## Section` header
+   - If unsure which section header, create under `## Section 8: Schedule Management` (or whatever section the video belongs to based on the TIA course structure)
+3. Update the "Last updated" date at top of question-bank.md
+4. Write the changes
+
+### Step 5: Move to Processed
+
+1. Create `pmp/CourseContent/processed/` if it doesn't exist
+2. Move each consumed file to `pmp/CourseContent/processed/`
+3. This prevents re-reading on future runs
+
+### Step 5.5: Write Refresher Manifest
+
+After processing, write or update `pmp/CourseContent/last-consumed.md` to track which questions are available for refresher quizzes.
+
+**If `last-consumed.md` does not exist**, create it:
+
+```markdown
+# Last Consumed
+
+date: [today's date]
+videos: [list of video numbers just processed]
+topics:
+  - [Topic 1]
+  - [Topic 2]
+
+## Unquizzed Questions
+
+| Video | Topic | Question ID | Quizzed? |
+|-------|-------|-------------|----------|
+| 99 | Develop Schedule | Q1 | no |
+| 99 | Develop Schedule | Q2 | no |
+```
+
+**If `last-consumed.md` already exists**, APPEND the new data:
+- Add today's date and new video numbers to the header fields
+- Add new topics to the topics list (skip duplicates)
+- Append new question rows to the Unquizzed Questions table
+- Do NOT overwrite existing rows — unquizzed questions from previous runs accumulate
+
+**Question ID** matches the Q number under the topic's `### [Topic]` section in the question bank (e.g., Q1 under `### Develop Schedule`).
+
+**Quizzed?** starts as `no` for all new questions. The `/pmp-quiz refresher` mode flips these to `yes` as questions are answered.
+
+### Step 6: Update Video Progress
+
+1. Read the video numbers from all processed files (both newly processed and previously in `processed/`)
+2. Find the highest video number — this is the latest completed video
+3. Calculate total videos completed (count all files in `processed/`)
+4. Note: Do NOT update `state/current.md` video count automatically — just report the new count so it can be updated at session end
+
+### Step 7: Report
+
+Output a consumption report:
+
+```
+## PMP Consume Report
+
+**Processed:** [N] transcript(s)
+**Videos:** [list video numbers]
+**Questions generated:** [total count]
+
+| Video | Topic | Questions Added | Section |
+|-------|-------|----------------|---------|
+| 99 | Develop Schedule | 7 | Section 8: Schedule Management |
+| 100 | [topic] | 5 | [section] |
+
+**Latest video:** [highest number]
+**Total processed to date:** [count in processed/]
+**New topics added to question bank:** [list any new ### sections created]
+**Refresher manifest:** Updated `pmp/CourseContent/last-consumed.md` — [N] new questions queued for refresher
+```
+
+---
+
+## Notes
+
+- The transcript is the primary source. The instructor's emphasis, examples, and "exam tips" are the most valuable material for question generation.
+- Questions should test understanding, not memorization. Scenario-based is always preferred.
+- If a transcript covers a topic already in the question bank, ADD questions (don't replace). Different angles on the same topic strengthen the bank.
+- Keep question explanations concise but include the "why" — this feeds into Revision Mode feedback.
+
+---
+
+*Skill created: 2026-04-14*

--- a/skills/pmp-quiz/progress/matt.md
+++ b/skills/pmp-quiz/progress/matt.md
@@ -1,6 +1,6 @@
 # PMP Progress: Matt
 
-Last updated: 2026-04-11
+Last updated: 2026-04-12
 
 ---
 
@@ -14,38 +14,38 @@ Last updated: 2026-04-11
 | Project Management Plan (master document) | 1/5 | 3/10 | 2026-04-05 | 2026-04-06 | 1 day | Active |
 | Functional Manager (resource assignment authority) | 1/5 | 3/10 | 2026-04-10 | 2026-04-11 | 1 day | Active |
 | Project Charter (authorization + PM authority) | 1/5 | 3/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
-| Project Bosses (Sponsor, Program Manager roles) | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
-| Product vs Project Management | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
+| Project Bosses (Sponsor, Program Manager roles) | 2/5 | 3/10 | 2026-04-12 | 2026-04-13 | 1 day | Active |
+| Product vs Project Management | 2/5 | 3/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
 | Areas of a Project (9 knowledge areas) | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
-| PM Approaches: Predictive vs Adaptive | 1/5 | 3/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
-| Organizational Structures (Functional, Matrix, Projectized) | 1/5 | 4/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
-| Risks vs Issues vs Assumptions vs Constraints | 1/5 | 4/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| PM Approaches: Predictive vs Adaptive | 2/5 | 5/10 | 2026-04-12 | 2026-04-13 | 1 day | Active |
+| Organizational Structures (Functional, Matrix, Projectized) | 2/5 | 7/10 | 2026-04-12 | 2026-04-13 | 1 day | Active |
+| Risks vs Issues vs Assumptions vs Constraints | 2/5 | 5/10 | 2026-04-12 | 2026-04-13 | 1 day | Active |
 | Project Constraints (6 constraints hexagon) | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
-| Emotional Intelligence in PM | 1/5 | 4/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
-| Leadership vs Management | 1/5 | 4/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
-| PMI Code of Ethics (Responsibility, Respect, Fairness, Honesty) | 1/5 | 2/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Emotional Intelligence in PM | 2/5 | 5/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Leadership vs Management | 2/5 | 5/10 | 2026-04-12 | 2026-04-13 | 1 day | Active |
+| PMI Code of Ethics (Responsibility, Respect, Fairness, Honesty) | 2/5 | 3/10 | 2026-04-12 | 2026-04-13 | 1 day | Active |
 | 12 Principles of Project Management | 1/5 | 2/10 | 2026-04-01 | 2026-04-02 | 1 day | Active |
 | Stewardship (Integrity, Care, Trustworthiness, Compliance) | 1/5 | 4/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
-| Collaborative Team Environment (authority, accountability, responsibility) | 1/5 | 4/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
-| Stakeholder Engagement (proactive, impacts on project) | 1/5 | 4/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Collaborative Team Environment (authority, accountability, responsibility) | 2/5 | 5/10 | 2026-04-12 | 2026-04-13 | 1 day | Active |
+| Stakeholder Engagement (proactive, impacts on project) | 2/5 | 5/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
 | Focus on Value (ultimate indicator of project success) | 1/5 | 3/10 | 2026-04-10 | 2026-04-11 | 1 day | Active |
-| Systems Thinking (holistic view, interdependencies) | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
-| Leadership Behaviors (leadership ≠ authority) | 1/5 | 3/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Systems Thinking (holistic view, interdependencies) | 1/5 | 3/10 | 2026-04-12 | 2026-04-13 | 1 day | Active |
+| Leadership Behaviors (leadership ≠ authority) | 2/5 | 5/10 | 2026-04-12 | 2026-04-13 | 1 day | Active |
 | Tailoring Based on Context ("just enough" process) | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
 | Build Quality into Processes and Deliverables | 1/5 | 3/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
-| Navigate Complexity (sources: human, system, uncertainty, tech) | 1/5 | 3/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
-| Optimize Risk Responses (positive/negative risks, appetite/threshold) | 1/5 | 2/10 | 2026-03-27 | 2026-03-28 | 1 day | Active |
+| Navigate Complexity (sources: human, system, uncertainty, tech) | 1/5 | 4/10 | 2026-04-12 | 2026-04-13 | 1 day | Active |
+| Optimize Risk Responses (positive/negative risks, appetite/threshold) | 2/5 | 3/10 | 2026-04-12 | 2026-04-13 | 1 day | Active |
 | Embrace Adaptability and Resiliency | 1/5 | 3/10 | 2026-04-05 | 2026-04-06 | 1 day | Active |
-| Enable Change (current state → future state) | 1/5 | 3/10 | 2026-04-01 | 2026-04-02 | 1 day | Active |
-| 5 Process Groups (Initiating, Planning, Executing, M&C, Closing) | 1/5 | 3/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Enable Change (current state → future state) | 2/5 | 4/10 | 2026-04-12 | 2026-04-13 | 1 day | Active |
+| 5 Process Groups (Initiating, Planning, Executing, M&C, Closing) | 2/5 | 5/10 | 2026-04-12 | 2026-04-13 | 1 day | Active |
 | 49 Processes (across 5 process groups) | 1/5 | 1/10 | 2026-04-10 | 2026-04-11 | 1 day | Active |
-| ITTO (Inputs, Tools & Techniques, Outputs) | 1/5 | 2/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| ITTO (Inputs, Tools & Techniques, Outputs) | 2/5 | 3/10 | 2026-04-12 | 2026-04-13 | 1 day | Active |
 | Common Inputs (PMP, EEF, OPA, Project Docs) | 1/5 | 2/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
-| Enterprise Environmental Factors (EEF) | 1/5 | 1/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
-| Organizational Process Assets (OPA) | 1/5 | 2/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
-| Project Documents vs Project Management Plan | 1/5 | 2/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
-| Expert Judgment (SME usage) | 1/5 | 1/10 | 2026-04-10 | 2026-04-11 | 1 day | Active |
-| Data Flow (Gathering → Analysis → Representation → Decision Making) | 1/5 | 2/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Enterprise Environmental Factors (EEF) | 2/5 | 2/10 | 2026-04-12 | 2026-04-13 | 1 day | Active |
+| Organizational Process Assets (OPA) | 2/5 | 3/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
+| Project Documents vs Project Management Plan | 2/5 | 5/10 | 2026-04-12 | 2026-04-13 | 1 day | Active |
+| Expert Judgment (SME usage) | 2/5 | 2/10 | 2026-04-12 | 2026-04-13 | 1 day | Active |
+| Data Flow (Gathering → Analysis → Representation → Decision Making) | 2/5 | 3/10 | 2026-04-11 | 2026-04-12 | 1 day | Active |
 
 ---
 
@@ -61,6 +61,9 @@ Last updated: 2026-04-11
 | 2026-04-10 | 10 | 10/10 | 49 Processes, OPA, Project Docs vs PMP, Expert Judgment, Common Inputs, Functional Manager, Collaborative Team Env, Stakeholder Engagement, Emotional Intelligence, Focus on Value |
 | 2026-04-11 | 10 | 8/10 | ITTO, Emotional Intelligence, Common Inputs, Collaborative Team Env, Data Flow, Leadership vs Mgmt, OPA, Project Docs vs PMP, Org Structures, PMI Code of Ethics |
 | 2026-04-11 | 10 | 7/10 | 5 Process Groups, Stewardship, Navigate Complexity, PM Approaches, Stakeholder Engagement, EEF, Leadership Behaviors, Build Quality, Risks vs Issues |
+| 2026-04-11 | 9 | 9/9 | OPA, Emotional Intelligence, Project Docs vs PMP, Org Structures, Product vs Project Mgmt, Data Flow, Leadership Behaviors, PM Approaches, Stakeholder Engagement |
+| 2026-04-12 | 10 | 10/10 | EEF, Collaborative Team Env, ITTO, Leadership Behaviors, PMI Code of Ethics, Project Docs vs PMP, Org Structures, Risks vs Issues, Enable Change, PM Approaches |
+| 2026-04-12 | 10 | 7/10 | 5 Process Groups, Project Bosses, Navigate Complexity, Org Structures, Project Docs vs PMP, Leadership vs Mgmt, Systems Thinking, Optimize Risk Responses, Expert Judgment |
 
 ---
 

--- a/skills/pmp-quiz/question-bank.md
+++ b/skills/pmp-quiz/question-bank.md
@@ -1,6 +1,6 @@
 # PMP Question Bank
 
-Last updated: 2026-03-25
+Last updated: 2026-04-14
 
 ---
 
@@ -572,6 +572,661 @@ B) Data Gathering → Data Analysis → Data Representation → Decision Making
 C) Decision Making → Data Gathering → Data Analysis → Data Representation
 D) Data Representation → Data Analysis → Data Gathering → Decision Making
 **A:** B) Data Gathering → Data Analysis → Data Representation → Decision Making.
+
+---
+
+## Section 8: The 49 Processes — Initiating
+
+### Develop Project Charter (Video 87)
+
+**Q1 - [SCENARIO]:** You are a new PM and your sponsor asks what must happen before you can assign team members and spend organizational resources on your project. What do you tell them?
+A) Complete the project management plan
+B) Get the project charter approved
+C) Create the WBS
+D) Identify all stakeholders
+**A:** B) The approved project charter formally authorizes the project and gives the PM authority to consume organizational resources. Without it, you cannot begin. *(Video 87)*
+
+**Q2 - MC:** Which TWO business documents are key inputs to the Develop Project Charter process?
+A) Business case and benefits management plan
+B) Scope statement and WBS
+C) Risk register and stakeholder register
+D) Project management plan and change log
+**A:** A) The business case justifies the investment, and the benefits management plan describes measurable benefits the project will produce once complete. *(Video 87)*
+
+**Q3 - [SCENARIO]:** A stakeholder asks why your project should be funded over three competing projects. Which document should you reference?
+A) The project management plan
+B) The business case
+C) The assumption log
+D) The stakeholder register
+**A:** B) The business case contains the justification — market demand, customer requests, legal requirements, ROI — proving the project is worth the investment. *(Video 87)*
+
+**Q4 - MC:** What level of detail does the project charter contain?
+A) Very detailed scope, schedule, and budget
+B) High-level scope, high-level budget, high-level schedule, and high-level risks
+C) Only the project manager's name and authority level
+D) Detailed work packages and activity lists
+**A:** B) The charter is high-level. It does not contain detailed specifications — those come later in planning. *(Video 87)*
+
+**Q5 - MC:** What is the difference between an assumption and a fact in the context of the assumption log?
+A) There is no difference
+B) An assumption is perceived to be true but unverified; a fact has been confirmed
+C) An assumption is always negative; a fact is always positive
+D) Assumptions are documented; facts are not
+**A:** B) Assumptions are perceived to be true and may constrain the project if proven false. Facts have been verified. The assumption log tracks these throughout the project. *(Video 87)*
+
+**Q6 - [SCENARIO]:** A contractor signs a service level agreement with your company to maintain internet at 99% availability. This agreement becomes an input to which process?
+A) Collect Requirements
+B) Develop Project Charter
+C) Plan Procurements
+D) Identify Stakeholders
+**A:** B) Agreements (contracts, SLAs, letters of intent) are inputs to Develop Project Charter because they initiate projects for the performing organization. *(Video 87)*
+
+---
+
+### Identify Stakeholders (Video 88)
+
+**Q1 - [SCENARIO]:** You just received your project charter. What should be your NEXT step?
+A) Begin writing the project management plan
+B) Identify who the project will affect — the stakeholders
+C) Create the WBS
+D) Develop the schedule
+**A:** B) After the charter is approved, the next process is Identify Stakeholders — determine who is affected by and can affect the project. *(Video 88)*
+
+**Q2 - MC:** How often should the Identify Stakeholders process be performed?
+A) Once, at the beginning of the project
+B) Only during initiation and planning
+C) Continuously throughout the project
+D) Only when a stakeholder leaves the project
+**A:** C) Stakeholders come and go. This process should be performed on a regular, continuous basis throughout the project lifecycle. *(Video 88)*
+
+**Q3 - MC:** A power/interest grid is used to:
+A) Calculate the project budget
+B) Map stakeholders by their level of authority and interest in the project
+C) Sequence project activities
+D) Identify project risks
+**A:** B) A power/interest grid plots stakeholders based on their power (authority) and interest level, helping the PM prioritize engagement. *(Video 88)*
+
+**Q4 - [SCENARIO]:** Your project will automate 50 jobs, eliminating those positions. Those employees are BEST described as:
+A) Positively impacted stakeholders with high interest
+B) Negatively impacted stakeholders who should be engaged carefully
+C) Passive stakeholders with no influence
+D) External stakeholders outside the project
+**A:** B) Stakeholders losing their jobs are negatively impacted. They likely have high interest and may resist the project — careful engagement is critical. *(Video 88)*
+
+**Q5 - MC:** The stakeholder register contains all of the following EXCEPT:
+A) Contact information and role on the project
+B) Communication preferences
+C) Detailed project budget allocations
+D) How they are affected by the project (positive/negative)
+**A:** C) The stakeholder register contains contact info, roles, communication preferences, expectations, needs, influence level, and impact — not budget allocations. *(Video 88)*
+
+**Q6 - MC:** The four directions of stakeholder influence are:
+A) Internal, external, positive, negative
+B) Upward, downward, outward, sideward
+C) High, medium, low, none
+D) Active, passive, supportive, resistant
+**A:** B) Upward (senior management), downward (team members), outward (external like regulators), sideward (peers/other PMs). *(Video 88)*
+
+---
+
+## Section 8: The 49 Processes — Planning
+
+### Develop Project Management Plan (Video 89)
+
+**Q1 - MC:** The project management plan is BEST described as:
+A) A single document listing the project schedule
+B) A comprehensive document outlining the basis of all work and how the work will be done
+C) The project charter with more detail added
+D) A list of all project risks
+**A:** B) The PM plan outlines what work will be done (baselines) and how to do it (management plans). It contains 18 components: 14 subsidiary plans and 4 baselines. *(Video 89)*
+
+**Q2 - [SCENARIO]:** A communication issue arises on your project. What should you do FIRST?
+A) Call an emergency meeting with all stakeholders
+B) Escalate to the sponsor
+C) Consult the communication management plan
+D) Send an email to the team
+**A:** C) The first thing a PM should do when a problem arises is consult the relevant management plan. The communication management plan has the steps to handle communication issues. *(Video 89)*
+
+**Q3 - MC:** What is the difference between a management plan and a baseline?
+A) They are the same thing
+B) A management plan is a how-to document; a baseline defines what the work is
+C) A baseline is a how-to document; a management plan defines what the work is
+D) Management plans are optional; baselines are mandatory
+**A:** B) Management plans = how-to documents (how to manage scope, cost, schedule, etc.). Baselines = what the work is (scope baseline, cost baseline, schedule baseline). *(Video 89)*
+
+**Q4 - [SCENARIO]:** A team member wants to change the project scope. What must happen before any change is made to the approved project management plan?
+A) The PM can approve the change directly
+B) A change request must be generated and approved by the CCB or sponsor
+C) The team can implement it if it improves the project
+D) Changes to the plan are not allowed
+**A:** B) Once the PM plan is approved, only an approved change request (via the change control board or sponsor) can modify it. *(Video 89)*
+
+**Q5 - MC:** The project management plan contains how many baselines?
+A) 2
+B) 3
+C) 4
+D) 5
+**A:** C) 4 baselines: scope baseline, schedule baseline, cost baseline, and performance measurement baseline. *(Video 89)*
+
+**Q6 - [SCENARIO]:** You inherited a project from a PM who kept the entire plan in their head. Nothing is written down. What is the BIGGEST risk?
+A) The project will cost more
+B) No one else can follow the plan, and if the PM leaves, the project has no documented guidance
+C) The sponsor will be upset
+D) The schedule will slip
+**A:** B) The PM plan should be a formal written document, not stored in someone's head. Without documentation, continuity is lost if the PM leaves. *(Video 89)*
+
+---
+
+### Plan Scope Management (Video 90)
+
+**Q1 - MC:** What is the difference between product scope and project scope?
+A) They are the same thing
+B) Product scope = features and functions of the product; project scope = the work required to deliver the product
+C) Project scope = features; product scope = the work
+D) Product scope is for agile only; project scope is for predictive only
+**A:** B) Product scope describes what the product does (features/functions). Project scope describes the work needed to deliver the product with those features. *(Video 90)*
+
+**Q2 - [SCENARIO]:** Your team finishes painting a room one day early with leftover paint. A team member decides to also paint the hallway, which was not in scope. This is an example of:
+A) Scope creep
+B) Gold plating
+C) Fast tracking
+D) Progressive elaboration
+**A:** B) Gold plating is doing extra work not in scope because you have extra time/resources. It should be avoided — do the work and only the work required. *(Video 90)*
+
+**Q3 - MC:** What is scope creep?
+A) Adding work through an approved change request
+B) Unauthorized additions to the project scope without updating the scope baseline
+C) Removing work from the scope
+D) A planned expansion of the project
+**A:** B) Scope creep is unauthorized work added without going through the change request process and updating the scope baseline. *(Video 90)*
+
+**Q4 - MC:** The process "Plan Scope Management" outputs the Scope Management Plan. What is the quick trick for remembering process-to-output naming?
+A) Add "Plan" to the end of the process name to get the output
+B) The output is always the same as the process name
+C) Move the word "Plan" from the beginning to the end: Plan Scope Management → Scope Management Plan
+D) There is no pattern
+**A:** C) Move "Plan" to the end. Plan Scope Management → Scope Management Plan. Plan Cost Management → Cost Management Plan. This works for all management plan processes. *(Video 90)*
+
+**Q5 - [SCENARIO]:** A stakeholder asks you to add a new feature. What is the CORRECT response?
+A) Add it immediately to keep the stakeholder happy
+B) Tell them it cannot be done
+C) Submit a change request, assess the impact, get it approved, then update the scope
+D) Add it but don't tell anyone
+**A:** C) The proper process: change request → assess impact → get approval from CCB/sponsor → update scope baseline. This prevents scope creep. *(Video 90)*
+
+---
+
+### Collect Requirements (Video 91)
+
+**Q1 - [SCENARIO]:** Your project is to renovate a kitchen, but you haven't gathered detailed requirements yet. Why is this a problem?
+A) You can't identify stakeholders without requirements
+B) You can't build an accurate schedule, budget, or risk plan without knowing exactly what the stakeholders want
+C) Requirements aren't needed for small projects
+D) You only need high-level requirements to start work
+**A:** B) Detailed requirements drive everything — schedule, budget, risk, quality, and resources. Without them, estimates will be inaccurate and you risk delivering the wrong thing. *(Video 91)*
+
+**Q2 - MC:** What is benchmarking in the context of collecting requirements?
+A) Comparing your project to a competitor's project
+B) A performance standard or industry minimum that the product must meet
+C) A type of risk analysis
+D) A method for sequencing activities
+**A:** B) Benchmarking establishes a performance target — an industry standard minimum the product must meet (e.g., a fingerprint reader must unlock in under 0.5 seconds). *(Video 91)*
+
+**Q3 - MC:** What is a prototype used for in requirements gathering?
+A) To create the final product
+B) To provide a working model stakeholders can interact with and give feedback on
+C) To estimate project costs
+D) To sequence project activities
+**A:** B) A prototype is a working model shown to stakeholders so they can interact with it and provide feedback before the final product is built. *(Video 91)*
+
+**Q4 - MC:** A requirements traceability matrix links each requirement back to:
+A) The project schedule
+B) Its source — who gave it and why it was added
+C) The project budget
+D) The risk register
+**A:** B) The traceability matrix traces each requirement to its source (which stakeholder requested it, or why it was added), enabling accountability and tracking throughout the project. *(Video 91)*
+
+**Q5 - MC:** According to Edward Deming, the "father of quality," the ultimate test of quality is:
+A) Zero defects
+B) Meeting all technical specifications
+C) Customer satisfaction
+D) Passing all inspections
+**A:** C) Customer satisfaction. Quality requirements are the things that, if missing or done poorly, make the customer unhappy. *(Video 91)*
+
+**Q6 - MC:** What term describes grouping large brainstormed ideas into categories?
+A) Mind mapping
+B) Affinity diagram
+C) Context diagram
+D) Benchmarking
+**A:** B) Affinity diagram. "Affinity" means grouping — it takes large sets of brainstormed ideas and groups them into logical categories. *(Video 91)*
+
+---
+
+### Define Scope (Video 92)
+
+**Q1 - [SCENARIO]:** You are asked: "If you could only produce ONE document for your entire project plan, what should it be?" The answer is:
+A) The project charter
+B) The risk register
+C) The project scope statement
+D) The stakeholder register
+**A:** C) The project scope statement. At a minimum, a project needs a well-defined scope that clearly states what the project will and will not do. *(Video 92)*
+
+**Q2 - MC:** A high-level scope statement increases the chance of:
+A) Accurate cost estimates
+B) Scope creep
+C) Better stakeholder engagement
+D) Faster project completion
+**A:** B) A high-level (vague) scope statement increases scope creep because stakeholders can ask for almost anything. The more detailed the scope, the less chance of scope creep. *(Video 92)*
+
+**Q3 - MC:** The project scope statement should include all of the following EXCEPT:
+A) Deliverables and acceptance criteria
+B) Exclusions — what the project will NOT do
+C) Detailed activity-level time estimates
+D) Constraints and high-level risks
+**A:** C) The scope statement describes deliverables, acceptance criteria, exclusions, constraints, and risks — not detailed activity durations (those come later in schedule management). *(Video 92)*
+
+**Q4 - [SCENARIO]:** Your scope statement says "renovate kitchen." A stakeholder asks you to also renovate the bathroom. How does a well-defined scope help you here?
+A) It doesn't help — you should accommodate the stakeholder
+B) A detailed scope statement listing specific kitchen deliverables makes it clear that bathroom work is out of scope, requiring a formal change request
+C) You should add the bathroom and update the charter
+D) Ignore the request
+**A:** B) A detailed scope with specific deliverables and exclusions makes it clear what is and isn't included. Adding bathroom work would require a change request. *(Video 92)*
+
+---
+
+### Create WBS (Video 93)
+
+**Q1 - MC:** The scope baseline consists of which three documents?
+A) Project charter, stakeholder register, risk register
+B) WBS, WBS dictionary, and project scope statement
+C) Activity list, milestone list, and network diagram
+D) Cost baseline, schedule baseline, and scope statement
+**A:** B) The scope baseline = WBS + WBS dictionary + project scope statement. *(Video 93)*
+
+**Q2 - MC:** In a WBS, the lowest-level items are called:
+A) Deliverables
+B) Activities
+C) Work packages
+D) Control accounts
+**A:** C) Work packages. They are the lowest level of the WBS and are later decomposed into activities for scheduling. *(Video 93)*
+
+**Q3 - [SCENARIO]:** A team member is doing work that does not appear anywhere on the WBS. What is the most likely issue?
+A) The WBS needs to be updated with a change request
+B) The team member is performing out-of-scope work (scope creep)
+C) The WBS dictionary is incomplete
+D) The work is part of progressive elaboration
+**A:** B) If it's not on the WBS, it's not in scope. Work outside the WBS is scope creep — it should not be done unless added through a formal change request. *(Video 93)*
+
+**Q4 - MC:** What does the WBS dictionary provide?
+A) A list of all project stakeholders
+B) Detailed information about each work package — who's assigned, cost estimates, due dates, and descriptions
+C) The project schedule
+D) Risk response strategies
+**A:** B) The WBS dictionary expands on each work package with additional details: assigned person, time/cost estimates, contractual info, and descriptions. *(Video 93)*
+
+**Q5 - MC:** What is the correct decomposition flow from scope to schedule?
+A) Activities → Work packages → Deliverables
+B) Deliverables → Activities → Work packages
+C) Deliverables (scope statement) → Work packages (WBS) → Activities (activity list)
+D) Work packages → Deliverables → Activities
+**A:** C) Deliverables come from the scope statement, are decomposed into work packages on the WBS, which are then decomposed into activities on the activity list. *(Video 93)*
+
+---
+
+### Plan Schedule Management (Video 94)
+
+**Q1 - MC:** The schedule management plan is BEST described as:
+A) The project schedule itself
+B) A how-to document defining procedures for planning, developing, managing, executing, and controlling the project schedule
+C) A list of all project milestones
+D) The critical path analysis
+**A:** B) Like all management plans, it's a how-to document. It establishes policies and procedures for how the schedule will be built and managed. *(Video 94)*
+
+**Q2 - [SCENARIO]:** You manage two projects — a 10-story building and a small kitchen renovation. Should they use the same schedule management approach?
+A) Yes, PMI requires a standard approach
+B) No, every project's scheduling procedures should be tailored to its size, complexity, and industry
+C) Yes, consistency is more important than tailoring
+D) Only if they're in the same organization
+**A:** B) The schedule management plan is unique to every project. A skyscraper and a kitchen renovation require very different scheduling approaches. *(Video 94)*
+
+---
+
+### Define Activities (Video 95)
+
+**Q1 - MC:** Activities are derived from:
+A) The project charter
+B) The stakeholder register
+C) Work packages on the WBS
+D) The risk register
+**A:** C) Activities are created by decomposing work packages from the WBS into specific, actionable tasks. *(Video 95)*
+
+**Q2 - [SCENARIO]:** A work package says "Buy paint." Is this an activity?
+A) Yes, it's specific enough
+B) No — the activities would be: research paint stores, check availability, travel to store, purchase paint, return
+C) Yes, if the PM approves it
+D) No, it's a deliverable
+**A:** B) "Buy paint" is a work package. Activities are the specific actions needed to complete it — researching, traveling, purchasing, etc. *(Video 95)*
+
+**Q3 - MC:** What is rolling wave planning?
+A) Planning the entire project in detail upfront
+B) Near-term work is planned in detail while long-term work remains at a high level, with details added as the project progresses
+C) Planning in reverse order from the end date
+D) A risk management technique
+**A:** B) Rolling wave planning is progressive elaboration — detailed planning for near-term work, high-level placeholders for future work that get refined over time. *(Video 95)*
+
+**Q4 - MC:** Each activity should map to how many work packages?
+A) As many as needed
+B) Exactly one
+C) At least two
+D) None — activities are independent
+**A:** B) Each activity maps to one and only one work package. One work package can have many activities, but each activity belongs to only one work package. *(Video 95)*
+
+**Q5 - MC:** The three main outputs of Define Activities are:
+A) WBS, WBS dictionary, scope baseline
+B) Activity list, activity attributes, milestone list
+C) Network diagram, schedule baseline, Gantt chart
+D) Risk register, assumption log, change log
+**A:** B) Activity list (all activities), activity attributes (additional info about each), and milestone list (key dates/accomplishments). *(Video 95)*
+
+---
+
+### Sequence Activities (Video 96)
+
+**Q1 - MC:** The MOST common relationship between activities is:
+A) Start-to-start
+B) Finish-to-finish
+C) Finish-to-start
+D) Start-to-finish
+**A:** C) Finish-to-start. Activity A finishes, then Activity B starts. This is the most common dependency type. *(Video 96)*
+
+**Q2 - MC:** A mandatory dependency (hard logic) means:
+A) The team chooses the sequence based on preference
+B) One activity MUST be completed before another can begin — there is a physical limitation
+C) Activities can be done in any order
+D) The dependency is external to the team
+**A:** B) Mandatory/hard logic means there's a physical limitation. Example: you must install hardware before installing software. *(Video 96)*
+
+**Q3 - [SCENARIO]:** Your schedule shows "paint room" followed immediately by "move furniture back." What scheduling concept are you missing?
+A) A lead
+B) A lag
+C) A mandatory dependency
+D) An external dependency
+**A:** B) A lag — you need a delay (e.g., one day) for the paint to dry before moving furniture back. Without the lag, you risk ruining the work. *(Video 96)*
+
+**Q4 - MC:** What is the difference between a lead and a lag?
+A) A lead is a delay; a lag is an overlap
+B) A lead is an overlap (successor starts before predecessor finishes); a lag is a delay (waiting time between activities)
+C) They are the same thing
+D) Leads apply to predecessors; lags apply to successors
+**A:** B) Lead = overlap (can start the next activity early). Lag = delay (must wait before starting the next activity). *(Video 96)*
+
+**Q5 - MC:** Waiting for a government permit before starting construction is an example of:
+A) Internal dependency
+B) Discretionary dependency
+C) External dependency
+D) Finish-to-finish relationship
+**A:** C) External dependency — something outside the control of the project team that must occur before work can proceed. *(Video 96)*
+
+**Q6 - MC:** A discretionary dependency (soft logic) means:
+A) The sequence is dictated by physical limitations
+B) The team has flexibility in the order — there's no physical constraint requiring a specific sequence
+C) The dependency comes from outside the organization
+D) The activities must happen simultaneously
+**A:** B) Discretionary/soft logic means the team can choose the order. Example: you could install Windows updates before or after Microsoft Office — either order works. *(Video 96)*
+
+---
+
+### Estimate Activity Durations (Video 97)
+
+**Q1 - MC:** Analogous (top-down) estimation is characterized by:
+A) High accuracy, high cost, detailed analysis
+B) Low accuracy, quick and cheap, uses historical data with limited information
+C) Uses statistical calculations and algorithms
+D) Requires detailed WBS decomposition
+**A:** B) Analogous estimation uses historical data, is quick and cheap to perform, but provides less accurate estimates because it relies on limited information. *(Video 97)*
+
+**Q2 - [SCENARIO]:** You need a quick estimate for a new project but have very little detail about the work. Which estimation technique is most appropriate?
+A) Bottom-up
+B) Parametric
+C) Analogous
+D) Three-point (PERT)
+**A:** C) Analogous (top-down) estimation. It's fast and cheap, using historical data from similar projects. It's best when detailed information isn't available yet. *(Video 97)*
+
+**Q3 - MC:** Bottom-up estimation is characterized by:
+A) Quick, cheap, uses historical data
+B) Very detailed, time-consuming, most accurate
+C) Uses three values to calculate an average
+D) Based on statistical algorithms
+**A:** B) Bottom-up estimation requires detailed work breakdown, is time-consuming and expensive, but produces the most accurate estimates. *(Video 97)*
+
+**Q4 - [SCENARIO]:** A programmer estimates a task will take 5 days. You tell the boss 7 days. The extra 2 days represent:
+A) Gold plating
+B) Scope creep
+C) Reserve analysis (contingency buffer for risks)
+D) Padding the estimate dishonestly
+**A:** C) Reserve analysis — adding extra time as a buffer for unpredictable events or risks. It's a legitimate estimation technique. *(Video 97)*
+
+**Q5 - MC:** Parametric estimation uses:
+A) Expert opinion only
+B) Historical data and statistical calculations (e.g., cost per square foot × total square feet)
+C) Three estimates averaged together
+D) Only the project charter
+**A:** B) Parametric uses statistical relationships — a formula like "10 minutes per square foot × 200 sq ft = 2,000 minutes." Accuracy depends on the quality of historical data. *(Video 97)*
+
+**Q6 - MC:** An estimate given without a range is problematic because:
+A) It implies 100% certainty, which is unrealistic for estimates
+B) It costs more
+C) PMI requires ranges on all estimates
+D) The sponsor won't accept it
+**A:** A) An estimate without a range (e.g., "10 days" instead of "10 days ±2 days") implies false certainty. Ranges set realistic expectations. *(Video 97)*
+
+---
+
+### PERT Calculations (Video 98)
+
+**Q1 - MC:** The PERT formula is:
+A) (O + R + P) / 3
+B) (O + 4R + P) / 6
+C) (O + P) / 2
+D) (4O + R + P) / 6
+**A:** B) (Optimistic + 4 × Realistic + Pessimistic) / 6. The realistic value is weighted 4x because it's the most likely outcome. *(Video 98)*
+
+**Q2 - [CALCULATION]:** A painter gives three estimates: best case = 2 days, most likely = 4 days, worst case = 12 days. What is the PERT estimate?
+A) 4 days
+B) 5 days
+C) 6 days
+D) 7 days
+**A:** B) 5 days. (2 + 4×4 + 12) / 6 = (2 + 16 + 12) / 6 = 30 / 6 = 5. *(Video 98)*
+
+**Q3 - MC:** Standard deviation in PERT gives you:
+A) The most likely duration
+B) The range of the estimate (plus or minus)
+C) The total project duration
+D) The cost of the activity
+**A:** B) Standard deviation = (P - O) / 6. It provides the range: the PERT estimate ± standard deviation. *(Video 98)*
+
+**Q4 - [CALCULATION]:** Given O=2, R=4, P=12, what is the standard deviation?
+A) 1.0
+B) 1.7
+C) 2.0
+D) 3.3
+**A:** B) 1.7. (12 - 2) / 6 = 10 / 6 = 1.67 ≈ 1.7. This means the estimate of 5 days is ±1.7 days. *(Video 98)*
+
+**Q5 - MC:** The triangular distribution formula differs from PERT because:
+A) It weights the realistic value 4x
+B) It's a simple average: (O + R + P) / 3 — no weighting
+C) It only uses two values
+D) It calculates standard deviation
+**A:** B) Triangular distribution = (O + R + P) / 3. Unlike PERT, it treats all three values equally (non-weighted average). *(Video 98)*
+
+**Q6 - [CALCULATION]:** Given O=10, R=15, P=40, what is the PERT estimate?
+A) 15.0
+B) 17.5
+C) 18.3
+D) 21.7
+**A:** C) 18.3. (10 + 4×15 + 40) / 6 = (10 + 60 + 40) / 6 = 110 / 6 = 18.3. *(Video 98)*
+
+---
+
+### Develop Schedule (Video 99)
+
+**Q1 - [SCENARIO]:** Your project schedule shows 90 days, but the sponsor says it must be done in 70 days. You decide to add more painters and use paint guns. This is an example of:
+A) Fast tracking
+B) Crashing
+C) Resource leveling
+D) Rolling wave planning
+**A:** B) Crashing — adding resources (people, equipment) to compress the schedule. Remember: crashing adds costs. *(Video 99)*
+
+**Q2 - [SCENARIO]:** Instead of adding resources, you decide to paint two rooms simultaneously that were originally planned sequentially. This is an example of:
+A) Crashing
+B) Resource leveling
+C) Fast tracking
+D) Schedule compression using PERT
+**A:** C) Fast tracking — running activities in parallel that were originally planned sequentially. It may not increase cost but generally increases risk. *(Video 99)*
+
+**Q3 - MC:** What is the KEY difference between crashing and fast tracking?
+A) Crashing reduces risk; fast tracking increases cost
+B) Crashing increases cost; fast tracking increases risk
+C) Both increase cost equally
+D) Both reduce the schedule without any trade-offs
+**A:** B) Crashing adds resources → increases cost. Fast tracking runs activities in parallel → increases risk. Both compress the schedule. *(Video 99)*
+
+**Q4 - MC:** Resource leveling is used when:
+A) The project is ahead of schedule
+B) A resource is over-allocated (assigned to multiple activities at the same time)
+C) The budget needs to be reduced
+D) Stakeholders request additional features
+**A:** B) Resource leveling flattens the schedule when resources are over-allocated. If someone is assigned to two tasks simultaneously, leveling sequences them — but this may extend the schedule. *(Video 99)*
+
+**Q5 - [SCENARIO]:** Andrew is assigned to install a server and install a workstation at the same time. The PM applies resource leveling. What is the likely impact?
+A) The project finishes sooner
+B) The schedule gets extended because Andrew now does tasks sequentially instead of simultaneously
+C) The cost is reduced
+D) No impact — resource leveling doesn't affect the schedule
+**A:** B) Resource leveling resolves over-allocation by sequencing tasks, but this pushes out the schedule because the work that was parallel is now sequential. *(Video 99)*
+
+**Q6 - MC:** In Agile release planning, a "release" is:
+A) A single iteration
+B) A set of iterations that produces enough usable features to deliver to the customer
+C) The final project deliverable only
+D) A sprint retrospective
+**A:** B) A release is a set of iterations that together create a usable product increment for the customer. Individual features alone may not be usable — a release combines enough features to be valuable. *(Video 99)*
+
+**Q7 - MC:** The schedule baseline is BEST described as:
+A) A detailed Gantt chart with all activity durations
+B) The original approved project start and end dates, used as a standard for measuring progress
+C) A list of all milestones
+D) The critical path
+**A:** B) The schedule baseline contains the original approved start and end dates — it's the standard against which actual progress is measured. It's simpler than the full project schedule. *(Video 99)*
+
+---
+
+### Critical Path Method — CPM (Videos 100-109)
+
+**Q1 - MC:** The critical path is defined as:
+A) The path with the most activities
+B) The shortest path through the network diagram
+C) The longest path through the network diagram, determining the minimum project duration
+D) The path with the most resources assigned
+**A:** C) The critical path is the longest path from start to finish. It determines the minimum project duration — the project cannot finish faster than the critical path allows. *(Video 102)*
+
+**Q2 - MC:** Float (also called slack or total float) is:
+A) The amount of time you can delay an activity without delaying the next activity
+B) The amount of time you can delay an activity without delaying the project end date
+C) Extra budget reserved for risks
+D) The time between two milestones
+**A:** B) Float/slack/total float = the amount of time an activity can be delayed without delaying the project end date. Activities on the critical path have zero float. *(Video 102)*
+
+**Q3 - [SCENARIO]:** Your network diagram has two paths: Path 1 (A-B-C-E) = 11 days and Path 2 (A-B-D-E) = 10 days. Activity D has a float of:
+A) 0 days
+B) 1 day
+C) 2 days
+D) 10 days
+**A:** B) 1 day. Path 2 is 1 day shorter than the critical path (11-10=1). Activity D can be delayed by 1 day without affecting the project end date. *(Video 102)*
+
+**Q4 - [SCENARIO]:** Activity B is on the critical path and is estimated at 2 days. If B takes 3 days instead, what happens?
+A) Nothing — there is buffer time
+B) The project end date is extended by 1 day
+C) Only the next activity is delayed
+D) The schedule is automatically compressed
+**A:** B) The project is extended by 1 day. Any delay to a critical path activity directly delays the project end date by the same amount — there is no float on critical path activities. *(Video 102)*
+
+**Q5 - MC:** The forward pass through a network diagram calculates:
+A) Late start and late finish for each activity
+B) Early start and early finish for each activity
+C) Float for each activity
+D) The project budget
+**A:** B) The forward pass calculates early start (ES) and early finish (EF) for every activity, starting from day 1. *(Video 104)*
+
+**Q6 - MC:** The formula for early finish (EF) in the forward pass is:
+A) EF = ES + Duration
+B) EF = ES + Duration - 1
+C) EF = ES - Duration + 1
+D) EF = LF - Duration
+**A:** B) EF = ES + Duration - 1. You subtract 1 because you start working on the ES day itself (it counts as a full day of work). *(Video 104)*
+
+**Q7 - [SCENARIO]:** During a forward pass, activities C (EF=9) and D (EF=8) both converge into activity E. What is E's early start?
+A) 8
+B) 9
+C) 10
+D) 11
+**A:** C) 10. At a path convergence going forward, E must wait for the biggest predecessor to finish. The biggest EF is 9 (from C), so E starts the next day: 9+1=10. *(Video 104)*
+
+**Q8 - MC:** The backward pass through a network diagram calculates:
+A) Early start and early finish
+B) Late start and late finish
+C) The critical path duration
+D) Free float only
+**A:** B) The backward pass calculates late start (LS) and late finish (LF), starting from the critical path end date and working backwards. *(Video 105)*
+
+**Q9 - MC:** The formula for late start (LS) in the backward pass is:
+A) LS = LF + Duration - 1
+B) LS = LF - Duration
+C) LS = LF - Duration + 1
+D) LS = ES - Duration
+**A:** C) LS = LF - Duration + 1. This is the inverse of the forward pass formula. *(Video 105)*
+
+**Q10 - [SCENARIO]:** During a backward pass, activities C (LS=6) and D (LS=7) both diverge from activity B. What is B's late finish?
+A) 5
+B) 6
+C) 7
+D) 8
+**A:** A) 5. At a path convergence going backwards, decrease the smallest late start by 1. The smallest LS is 6 (from C), so B's LF = 6-1 = 5. Forward: increment the biggest. Backward: decrease the smallest. *(Video 105)*
+
+**Q11 - MC:** How do you calculate total float for an activity?
+A) ES - LS or EF - LF
+B) LS - ES or LF - EF
+C) ES + EF - LS - LF
+D) Duration - ES
+**A:** B) Total float = LS - ES, or equivalently LF - EF. Both give the same result. Quick tip: bottom numbers minus top numbers, left or right side. *(Video 103)*
+
+**Q12 - MC:** How do you know an activity is on the critical path by looking at its ES, EF, LS, and LF values?
+A) ES is always 1
+B) ES = LS and EF = LF (top numbers equal bottom numbers, float = 0)
+C) The activity has the longest duration
+D) The activity has the most resources
+**A:** B) When ES = LS and EF = LF, the float is zero — the activity is on the critical path. There is no room for delay. *(Video 105)*
+
+**Q13 - MC:** What is the difference between total float and free float?
+A) They are the same thing
+B) Total float = delay without delaying the project; free float = delay without delaying the NEXT activity
+C) Free float = delay without delaying the project; total float = delay without delaying the next activity
+D) Total float applies to critical path activities only
+**A:** B) Total float measures delay before the project is impacted. Free float measures delay before the next activity is impacted. Free float ≤ total float. *(Video 106)*
+
+**Q14 - MC:** The formula for free float is:
+A) LS - ES
+B) LF - EF
+C) ES(next activity) - EF(current activity) - 1
+D) LF(next activity) - EF(current activity)
+**A:** C) Free float = ES of the next activity - EF of the current activity - 1. *(Video 106)*
+
+**Q15 - [SCENARIO]:** On a complex network diagram with 8+ paths, what is the fastest way to identify the critical path?
+A) Calculate all paths and find the longest
+B) Do the forward and backward pass — activities where top numbers equal bottom numbers (zero float) are on the critical path
+C) Ask the team which activities are most important
+D) Use only the backward pass
+**A:** B) For complex diagrams, doing forward + backward passes is faster than listing all paths. Activities with zero float (ES=LS, EF=LF) are on the critical path. *(Video 109)*
 
 ---
 


### PR DESCRIPTION
## Summary
- New `/pmp-consume` slash command: reads PMP video transcripts from `pmp/CourseContent/`, generates exam-style questions, adds to question bank, moves processed files, writes refresher manifest
- New **refresher mode** for `/pmp-quiz`: quizzes on recently consumed content with configurable cap (default 15), updates progress files with confidence scoring
- **87 new questions** added to question bank covering videos 87-109 (Initiating, Planning, and Critical Path Method)
- Synced Matt's quiz progress from Apr 11-12 sessions

## Test plan
- [ ] Run `/pmp-consume` with new transcripts in `pmp/CourseContent/`
- [ ] Verify questions appear in `skills/pmp-quiz/question-bank.md`
- [ ] Run `/pmp-quiz Matt refresher` and confirm manifest tracking works
- [ ] Verify progress file updates after refresher quiz

🤖 Generated with [Claude Code](https://claude.com/claude-code)